### PR TITLE
fix: detect discoverable endpoint name conflicts to prevent controller loop

### DIFF
--- a/controllers/controller/devworkspacerouting/devworkspacerouting_controller_test.go
+++ b/controllers/controller/devworkspacerouting/devworkspacerouting_controller_test.go
@@ -493,6 +493,42 @@ var _ = Describe("DevWorkspaceRouting Controller", func() {
 				}
 				return updatedDWR.Status.Phase, nil
 			}, timeout, interval).Should(Equal(controllerv1alpha1.RoutingFailed), "DevWorkspaceRouting should be in failed phase")
+
+		})
+		It("Fails second DevWorkspaceRouting when discoverable endpoint conflicts with existing workspace", func() {
+			// DWR-A (testWorkspaceID) is already created and RoutingReady from BeforeEach.
+			// Create DWR-B with the same discoverable endpoint name — should enter RoutingFailed.
+			By("Creating second DevWorkspaceRouting with conflicting discoverable endpoint name")
+			dwrBName := "dwr-conflict-test"
+			createDWR("test-id-2", dwrBName)
+			defer deleteDevWorkspaceRouting(dwrBName)
+
+			By("Checking DWR-B reaches RoutingFailed with conflict message")
+			dwrBNN := namespacedName(dwrBName, testNamespace)
+			dwrB := &controllerv1alpha1.DevWorkspaceRouting{}
+			Eventually(func() (controllerv1alpha1.DevWorkspaceRoutingPhase, error) {
+				if err := k8sClient.Get(ctx, dwrBNN, dwrB); err != nil {
+					return "", err
+				}
+				return dwrB.Status.Phase, nil
+			}, timeout, interval).Should(Equal(controllerv1alpha1.RoutingFailed),
+				"DWR-B should fail due to discoverable endpoint conflict")
+
+			Expect(dwrB.Status.Message).Should(ContainSubstring(common.EndpointName(discoverableEndpointName)),
+				"Failure message should mention the conflicting endpoint name")
+			Expect(dwrB.Status.Message).Should(ContainSubstring("conflict"),
+				"Failure message should mention conflict")
+
+			By("Verifying DWR-A remains healthy")
+			dwrANN := namespacedName(devWorkspaceRoutingName, testNamespace)
+			dwrA := &controllerv1alpha1.DevWorkspaceRouting{}
+			Consistently(func() (controllerv1alpha1.DevWorkspaceRoutingPhase, error) {
+				if err := k8sClient.Get(ctx, dwrANN, dwrA); err != nil {
+					return "", err
+				}
+				return dwrA.Status.Phase, nil
+			}, timeout/2, interval).Should(Equal(controllerv1alpha1.RoutingReady),
+				"DWR-A should remain in RoutingReady and not be affected by the conflict")
 		})
 	})
 })

--- a/controllers/controller/devworkspacerouting/solvers/common.go
+++ b/controllers/controller/devworkspacerouting/solvers/common.go
@@ -46,7 +46,7 @@ func GetDiscoverableServicesForEndpoints(endpoints map[string]controllerv1alpha1
 
 			if endpoint.Attributes.GetBoolean(string(controllerv1alpha1.DiscoverableAttribute), nil) {
 				// Create service with name matching endpoint
-				// TODO: This could cause a reconcile conflict if multiple workspaces define the same discoverable endpoint
+				// Conflict detection for identically-named discoverable endpoints is handled in syncServices() via checkDiscoverableServiceConflict.
 				// Also endpoint names may not be valid as service names
 				servicePort := corev1.ServicePort{
 					Name:       common.EndpointName(endpoint.Name),

--- a/controllers/controller/devworkspacerouting/sync_services.go
+++ b/controllers/controller/devworkspacerouting/sync_services.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,11 +22,44 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 )
+
+// checkDiscoverableServiceConflict checks whether any of the given spec services (those that are
+// discoverable) already exist in the cluster and are owned by a different DevWorkspace. If so, it
+// returns an UnrecoverableSyncError so the controller marks the routing as failed with a clear
+// user-visible message instead of looping forever.
+func checkDiscoverableServiceConflict(ctx context.Context, cl client.Client, routing *controllerv1alpha1.DevWorkspaceRouting, specServices []corev1.Service) error {
+	for _, service := range specServices {
+		if service.Annotations[constants.DevWorkspaceDiscoverableServiceAnnotation] != "true" {
+			continue
+		}
+		existingService := &corev1.Service{}
+		err := cl.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: routing.Namespace}, existingService)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		// Same workspace owns this service -- idempotent re-reconcile, no conflict
+		if existingService.Labels[constants.DevWorkspaceIDLabel] == routing.Spec.DevWorkspaceId {
+			continue
+		}
+		// NOTE: In production this uses the caching client; a narrow window exists where a
+		// freshly-created service may not yet be in cache, causing a requeue before this
+		// check fires on the next reconcile. This is acceptable convergence behavior.
+return &sync.UnrecoverableSyncError{
+			Cause: fmt.Errorf("Discoverable endpoint %q conflicts with an endpoint already defined by another DevWorkspace in this namespace. Rename the endpoint to resolve the conflict.", service.Name),
+		}
+	}
+	return nil
+}
 
 func (r *DevWorkspaceRoutingReconciler) syncServices(routing *controllerv1alpha1.DevWorkspaceRouting, specServices []corev1.Service) (ok bool, clusterServices []corev1.Service, err error) {
 	servicesInSync := true
@@ -43,6 +76,10 @@ func (r *DevWorkspaceRoutingReconciler) syncServices(routing *controllerv1alpha1
 			return false, nil, err
 		}
 		servicesInSync = false
+	}
+
+	if err := checkDiscoverableServiceConflict(context.TODO(), r.Client, routing, specServices); err != nil {
+		return false, nil, err
 	}
 
 	clusterAPI := sync.ClusterAPI{


### PR DESCRIPTION
## Summary

Fixes eclipse-che/che#23231

### Root cause

Discoverable endpoints create Kubernetes Services named using only `EndpointName(endpoint.Name)` — a static, namespace-scoped name derived solely from the endpoint name. When two DevWorkspaces in the same namespace use the same discoverable endpoint name, both try to own the same Service. This causes an infinite reconciliation loop. Both workspaces hang on Preparing Service indefinitely.

### Fix

Added `checkDiscoverableServiceConflict()` in `sync_services.go`. Before calling `SyncObjectWithCluster`, it checks if a Service with the target name already exists and belongs to a different workspace. If so, it returns `UnrecoverableSyncError`, which causes the controller to call `markRoutingFailed` with a clear user-visible message.

The check is idempotent — same-workspace re-reconciles pass through normally.

### Recovery procedure

After renaming the conflicting endpoint in the devfile, the workspace that entered RoutingFailed must be deleted and recreated (RoutingFailed is a terminal state).

### Test coverage

Added integration test in `devworkspacerouting_controller_test.go`:
- Creates two DWRs with the same discoverable endpoint name
- Asserts the second DWR enters RoutingFailed with the conflict message
- Asserts the first DWR remains healthy (using Consistently)