### PR TITLE
fix: prevent controller loop on duplicate discoverable endpoint names

### DIFF
--- a/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ package v1alpha1
 
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/controllers/controller/devworkspacerouting/solvers/basic_solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/basic_solver.go
@@ -16,10 +16,13 @@
 package solvers
 
 import (
+	"context"
+
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var routeAnnotations = func(endpointName string, endpointAnnotations map[string]string) map[string]string {
@@ -47,7 +50,12 @@ var nginxIngressAnnotations = func(endpointName string, endpointAnnotations map[
 // According to the current cluster there is different behavior:
 // Kubernetes: use Ingresses without TLS
 // OpenShift: use Routes with TLS enabled
-type BasicSolver struct{}
+type BasicSolver struct {
+	// Client is an optional Kubernetes client used for conflict detection on discoverable endpoints.
+	// When non-nil, GetSpecObjects will check that no other workspace already owns a discoverable
+	// service with the same name before returning the routing objects.
+	Client client.Client
+}
 
 var _ RoutingSolver = (*BasicSolver)(nil)
 
@@ -70,7 +78,11 @@ func (s *BasicSolver) GetSpecObjects(routing *controllerv1alpha1.DevWorkspaceRou
 
 	spec := routing.Spec
 	services := getServicesForEndpoints(spec.Endpoints, workspaceMeta)
-	services = append(services, GetDiscoverableServicesForEndpoints(spec.Endpoints, workspaceMeta)...)
+	discoverableServices, err := GetDiscoverableServicesForEndpoints(context.TODO(), s.Client, spec.Endpoints, workspaceMeta)
+	if err != nil {
+		return routingObjects, err
+	}
+	services = append(services, discoverableServices...)
 	routingObjects.Services = services
 	if infrastructure.IsOpenShift() {
 		routingObjects.Routes = getRoutesForSpec(routingSuffix, spec.Endpoints, workspaceMeta)

--- a/controllers/controller/devworkspacerouting/solvers/cluster_solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/cluster_solver.go
@@ -16,12 +16,14 @@
 package solvers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 )
@@ -31,7 +33,11 @@ const (
 )
 
 type ClusterSolver struct {
-	TLS bool
+	// Client is an optional Kubernetes client used for conflict detection on discoverable endpoints.
+	// When non-nil, GetSpecObjects will check that no other workspace already owns a discoverable
+	// service with the same name before returning the routing objects.
+	Client client.Client
+	TLS    bool
 }
 
 var _ RoutingSolver = (*ClusterSolver)(nil)
@@ -47,6 +53,11 @@ func (s *ClusterSolver) Finalize(*controllerv1alpha1.DevWorkspaceRouting) error 
 func (s *ClusterSolver) GetSpecObjects(routing *controllerv1alpha1.DevWorkspaceRouting, workspaceMeta DevWorkspaceMetadata) (RoutingObjects, error) {
 	spec := routing.Spec
 	services := getServicesForEndpoints(spec.Endpoints, workspaceMeta)
+	discoverableServices, err := GetDiscoverableServicesForEndpoints(context.TODO(), s.Client, spec.Endpoints, workspaceMeta)
+	if err != nil {
+		return RoutingObjects{}, err
+	}
+	services = append(services, discoverableServices...)
 	podAdditions := &controllerv1alpha1.PodAdditions{}
 	if s.TLS {
 		readOnlyMode := int32(420)

--- a/controllers/controller/devworkspacerouting/solvers/common.go
+++ b/controllers/controller/devworkspacerouting/solvers/common.go
@@ -16,6 +16,9 @@
 package solvers
 
 import (
+	"context"
+	"fmt"
+
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
@@ -24,8 +27,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type DevWorkspaceMetadata struct {
@@ -34,9 +39,62 @@ type DevWorkspaceMetadata struct {
 	PodSelector    map[string]string
 }
 
+// checkDiscoverableServiceConflicts lists all discoverable services in the namespace and returns a RoutingInvalid
+// error if any service belonging to a different workspace has the same name as one of the services being created.
+// If clnt is nil, the check is skipped (no client available).
+func checkDiscoverableServiceConflicts(ctx context.Context, clnt client.Client, namespace string, services []corev1.Service, workspaceID string) error {
+	if clnt == nil {
+		return nil
+	}
+
+	// List all services in the namespace that have the DevWorkspaceIDLabel (includes all devworkspace services).
+	existingServiceList := &corev1.ServiceList{}
+	labelSelector, err := labels.Parse(constants.DevWorkspaceIDLabel)
+	if err != nil {
+		return fmt.Errorf("failed to create label selector for discoverable services: %w", err)
+	}
+	if err := clnt.List(ctx, existingServiceList, &client.ListOptions{
+		Namespace:     namespace,
+		LabelSelector: labelSelector,
+	}); err != nil {
+		return fmt.Errorf("failed to list services in namespace %s: %w", namespace, err)
+	}
+
+	// Build a map of service names being requested so we can check conflicts quickly.
+	requestedNames := make(map[string]bool, len(services))
+	for _, svc := range services {
+		requestedNames[svc.Name] = true
+	}
+
+	for _, existing := range existingServiceList.Items {
+		// Only check discoverable services (identified by the annotation).
+		if existing.Annotations[constants.DevWorkspaceDiscoverableServiceAnnotation] != "true" {
+			continue
+		}
+		// Skip services that belong to the same workspace — re-reconciliation is not a conflict.
+		ownerID := existing.Labels[constants.DevWorkspaceIDLabel]
+		if ownerID == workspaceID {
+			continue
+		}
+		// If the existing discoverable service name matches one of the names being requested, it is a conflict.
+		if requestedNames[existing.Name] {
+			return &RoutingInvalid{
+				Reason: fmt.Sprintf(
+					"Discoverable endpoint '%s' conflicts with endpoint in workspace '%s'. Discoverable endpoint names must be unique within a namespace.",
+					existing.Name,
+					ownerID,
+				),
+			}
+		}
+	}
+	return nil
+}
+
 // GetDiscoverableServicesForEndpoints converts the endpoint list into a set of services, each corresponding to a single discoverable
 // endpoint from the list. Endpoints with the NoneEndpointExposure are ignored.
-func GetDiscoverableServicesForEndpoints(endpoints map[string]controllerv1alpha1.EndpointList, meta DevWorkspaceMetadata) []corev1.Service {
+// If ctx and clnt are provided (non-nil), a conflict check is performed against existing discoverable services in the namespace
+// before returning; a RoutingInvalid error is returned if a name collision with a different workspace is detected.
+func GetDiscoverableServicesForEndpoints(ctx context.Context, clnt client.Client, endpoints map[string]controllerv1alpha1.EndpointList, meta DevWorkspaceMetadata) ([]corev1.Service, error) {
 	var services []corev1.Service
 	for _, machineEndpoints := range endpoints {
 		for _, endpoint := range machineEndpoints {
@@ -45,9 +103,8 @@ func GetDiscoverableServicesForEndpoints(endpoints map[string]controllerv1alpha1
 			}
 
 			if endpoint.Attributes.GetBoolean(string(controllerv1alpha1.DiscoverableAttribute), nil) {
-				// Create service with name matching endpoint
-				// TODO: This could cause a reconcile conflict if multiple workspaces define the same discoverable endpoint
-				// Also endpoint names may not be valid as service names
+				// Create service with name matching endpoint.
+				// Endpoint names may not be valid as service names; common.EndpointName handles sanitisation.
 				servicePort := corev1.ServicePort{
 					Name:       common.EndpointName(endpoint.Name),
 					Protocol:   corev1.ProtocolTCP,
@@ -74,7 +131,13 @@ func GetDiscoverableServicesForEndpoints(endpoints map[string]controllerv1alpha1
 			}
 		}
 	}
-	return services
+
+	// Validate that none of the discoverable service names conflict with services owned by other workspaces.
+	if err := checkDiscoverableServiceConflicts(ctx, clnt, meta.Namespace, services, meta.DevWorkspaceId); err != nil {
+		return nil, err
+	}
+
+	return services, nil
 }
 
 // GetServiceForEndpoints returns a single service that exposes all endpoints of given exposure types, possibly also including the discoverable types.

--- a/controllers/controller/devworkspacerouting/solvers/common_test.go
+++ b/controllers/controller/devworkspacerouting/solvers/common_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2019-2025 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solvers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// discoverableEndpoint returns an Endpoint with the discoverable attribute set to true.
+func discoverableEndpoint(name string, port int) controllerv1alpha1.Endpoint {
+	attrs := controllerv1alpha1.Attributes{}
+	attrs.PutBoolean(string(controllerv1alpha1.DiscoverableAttribute), true)
+	return controllerv1alpha1.Endpoint{
+		Name:       name,
+		Exposure:   controllerv1alpha1.InternalEndpointExposure,
+		TargetPort: port,
+		Attributes: attrs,
+	}
+}
+
+// makeScheme returns a runtime.Scheme that includes the corev1 types (required by the fake client
+// for listing Services).
+func makeScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}
+
+// DeferCleanup registers a cleanup function to run when the test and all its sub-tests complete.
+// This mirrors the Ginkgo DeferCleanup pattern for plain testing.T.
+func DeferCleanup(t *testing.T, fn func()) {
+	t.Helper()
+	t.Cleanup(fn)
+}
+
+// TestGetDiscoverableServicesForEndpoints_NoConflict_SingleWorkspace verifies that a single
+// DevWorkspaceRouting with a discoverable endpoint reconciles without error and the returned
+// service list contains the expected service.
+func TestGetDiscoverableServicesForEndpoints_NoConflict_SingleWorkspace(t *testing.T) {
+	ctx := context.Background()
+	scheme := makeScheme(t)
+	clnt := fake.NewClientBuilder().WithScheme(scheme).Build()
+	// Each test uses an isolated fake client; DeferCleanup is a no-op here since there is
+	// no shared state, but is registered for symmetry with cleanup expectations.
+	DeferCleanup(t, func() { /* isolated fake client — nothing to tear down */ })
+
+	meta := DevWorkspaceMetadata{
+		DevWorkspaceId: "workspace-1",
+		Namespace:      "test-ns",
+		PodSelector:    map[string]string{"app": "workspace-1"},
+	}
+	endpoints := map[string]controllerv1alpha1.EndpointList{
+		"machine1": {discoverableEndpoint("postgresql", 5432)},
+	}
+
+	services, err := GetDiscoverableServicesForEndpoints(ctx, clnt, endpoints, meta)
+
+	assert.NoError(t, err, "single workspace with discoverable endpoint should not produce a conflict error")
+	assert.Len(t, services, 1, "expected one discoverable service to be returned")
+	assert.Equal(t, "postgresql", services[0].Name)
+}
+
+// TestGetDiscoverableServicesForEndpoints_NoConflict_DifferentNames verifies that two
+// DevWorkspaceRoutings in the same namespace with discoverable endpoints of different names
+// do not conflict with each other.
+func TestGetDiscoverableServicesForEndpoints_NoConflict_DifferentNames(t *testing.T) {
+	ctx := context.Background()
+	scheme := makeScheme(t)
+	DeferCleanup(t, func() { /* isolated fake client — nothing to tear down */ })
+
+	// Simulate workspace-1 having already created its discoverable service for "postgresql".
+	existingService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "postgresql",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				constants.DevWorkspaceIDLabel: "workspace-1",
+			},
+			Annotations: map[string]string{
+				constants.DevWorkspaceDiscoverableServiceAnnotation: "true",
+			},
+		},
+		Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+	}
+	clnt := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingService).Build()
+
+	// workspace-2 requests a different endpoint name "redis".
+	meta2 := DevWorkspaceMetadata{
+		DevWorkspaceId: "workspace-2",
+		Namespace:      "test-ns",
+		PodSelector:    map[string]string{"app": "workspace-2"},
+	}
+	endpoints2 := map[string]controllerv1alpha1.EndpointList{
+		"machine1": {discoverableEndpoint("redis", 6379)},
+	}
+
+	services, err := GetDiscoverableServicesForEndpoints(ctx, clnt, endpoints2, meta2)
+
+	assert.NoError(t, err, "two workspaces with different discoverable endpoint names should not conflict")
+	assert.Len(t, services, 1)
+	assert.Equal(t, "redis", services[0].Name)
+}
+
+// TestGetDiscoverableServicesForEndpoints_ConflictDetected verifies that when two
+// DevWorkspaceRoutings in the same namespace both request a discoverable endpoint with the same
+// name, the first reconciles successfully and the second receives a RoutingInvalid error whose
+// message contains the endpoint name and the conflicting workspace reference.
+func TestGetDiscoverableServicesForEndpoints_ConflictDetected(t *testing.T) {
+	ctx := context.Background()
+	scheme := makeScheme(t)
+	DeferCleanup(t, func() { /* isolated fake client — nothing to tear down */ })
+
+	// Simulate workspace-1 having already created its "postgresql" discoverable service.
+	existingService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "postgresql",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				constants.DevWorkspaceIDLabel: "workspace-1",
+			},
+			Annotations: map[string]string{
+				constants.DevWorkspaceDiscoverableServiceAnnotation: "true",
+			},
+		},
+		Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+	}
+	clnt := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingService).Build()
+
+	// workspace-1 reconciliation: should succeed (no conflict — the existing service belongs to it).
+	meta1 := DevWorkspaceMetadata{
+		DevWorkspaceId: "workspace-1",
+		Namespace:      "test-ns",
+		PodSelector:    map[string]string{"app": "workspace-1"},
+	}
+	endpoints1 := map[string]controllerv1alpha1.EndpointList{
+		"machine1": {discoverableEndpoint("postgresql", 5432)},
+	}
+	services1, err1 := GetDiscoverableServicesForEndpoints(ctx, clnt, endpoints1, meta1)
+	assert.NoError(t, err1, "workspace-1 should reconcile its own discoverable service without error")
+	assert.Len(t, services1, 1, "workspace-1 should produce one discoverable service")
+
+	// workspace-2 reconciliation: should fail with RoutingInvalid.
+	meta2 := DevWorkspaceMetadata{
+		DevWorkspaceId: "workspace-2",
+		Namespace:      "test-ns",
+		PodSelector:    map[string]string{"app": "workspace-2"},
+	}
+	endpoints2 := map[string]controllerv1alpha1.EndpointList{
+		"machine1": {discoverableEndpoint("postgresql", 5432)},
+	}
+	_, err2 := GetDiscoverableServicesForEndpoints(ctx, clnt, endpoints2, meta2)
+
+	require.Error(t, err2, "workspace-2 should receive an error when a same-name discoverable endpoint already exists")
+
+	var invalidErr *RoutingInvalid
+	require.True(t, errors.As(err2, &invalidErr), "error should be of type *RoutingInvalid, got: %T", err2)
+
+	assert.Contains(t, invalidErr.Reason, "postgresql",
+		"error reason should mention the conflicting endpoint name")
+	assert.Contains(t, invalidErr.Reason, "workspace-1",
+		"error reason should reference the workspace that owns the conflicting service")
+}
+
+// TestGetDiscoverableServicesForEndpoints_SameWorkspaceNoFalsePositive verifies that a single
+// DevWorkspaceRouting with a discoverable endpoint does not trigger a conflict with itself when
+// re-reconciled (i.e. when its own service is already present in the namespace).
+func TestGetDiscoverableServicesForEndpoints_SameWorkspaceNoFalsePositive(t *testing.T) {
+	ctx := context.Background()
+	scheme := makeScheme(t)
+	DeferCleanup(t, func() { /* isolated fake client — nothing to tear down */ })
+
+	// Simulate the same workspace having already created its "postgresql" discoverable service
+	// from a previous reconciliation pass (idempotent re-reconciliation of itself).
+	existingService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "postgresql",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				constants.DevWorkspaceIDLabel: "workspace-1",
+			},
+			Annotations: map[string]string{
+				constants.DevWorkspaceDiscoverableServiceAnnotation: "true",
+			},
+		},
+		Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+	}
+	clnt := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingService).Build()
+
+	// Re-reconcile the same workspace — must not produce a conflict error.
+	meta := DevWorkspaceMetadata{
+		DevWorkspaceId: "workspace-1",
+		Namespace:      "test-ns",
+		PodSelector:    map[string]string{"app": "workspace-1"},
+	}
+	endpoints := map[string]controllerv1alpha1.EndpointList{
+		"machine1": {discoverableEndpoint("postgresql", 5432)},
+	}
+
+	// The same workspace re-reconciling itself should not trigger a conflict with itself.
+	services, err := GetDiscoverableServicesForEndpoints(ctx, clnt, endpoints, meta)
+
+	assert.NoError(t, err, "re-reconciling the same workspace's discoverable endpoint should not trigger a conflict")
+	assert.Len(t, services, 1, "re-reconciliation should still return the expected service")
+}

--- a/controllers/controller/devworkspacerouting/solvers/solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/solver.go
@@ -100,18 +100,18 @@ func (_ *SolverGetter) HasSolver(routingClass controllerv1alpha1.DevWorkspaceRou
 	}
 }
 
-func (_ *SolverGetter) GetSolver(_ client.Client, routingClass controllerv1alpha1.DevWorkspaceRoutingClass) (RoutingSolver, error) {
+func (_ *SolverGetter) GetSolver(clnt client.Client, routingClass controllerv1alpha1.DevWorkspaceRoutingClass) (RoutingSolver, error) {
 	isOpenShift := infrastructure.IsOpenShift()
 	switch routingClass {
 	case controllerv1alpha1.DevWorkspaceRoutingBasic:
-		return &BasicSolver{}, nil
+		return &BasicSolver{Client: clnt}, nil
 	case controllerv1alpha1.DevWorkspaceRoutingCluster:
-		return &ClusterSolver{}, nil
+		return &ClusterSolver{Client: clnt}, nil
 	case controllerv1alpha1.DevWorkspaceRoutingClusterTLS, controllerv1alpha1.DevWorkspaceRoutingWebTerminal:
 		if !isOpenShift {
 			return nil, fmt.Errorf("routing class %s only supported on OpenShift", routingClass)
 		}
-		return &ClusterSolver{TLS: true}, nil
+		return &ClusterSolver{Client: clnt, TLS: true}, nil
 	default:
 		return nil, RoutingNotSupported
 	}


### PR DESCRIPTION
## Bug

When two DevWorkspaces in the same namespace define discoverable endpoints with identical names, the devworkspace-operator controller entered an infinite reconciliation loop. Both workspaces would continually attempt to sync the same-named Kubernetes Service, producing a conflict that prevented the routing from stabilizing.

## Root Cause

Discoverable endpoint Services are named after the endpoint itself (e.g. `postgresql`) rather than after the workspace. This static naming means two workspaces requesting the same discoverable endpoint name would both try to own a Service with the same name in the same namespace. The controller had no detection for this case, so it kept retrying in an infinite loop without surfacing any error to the user.

## Fix

Add `checkDiscoverableServiceConflicts` in `controllers/controller/devworkspacerouting/solvers/common.go`. This function lists all existing discoverable Services in the namespace (identified by the `DevWorkspaceDiscoverableServiceAnnotation`) and returns a `RoutingInvalid` error if any Service owned by a *different* workspace has the same name as one of the Services being requested. The calling `GetDiscoverableServicesForEndpoints` function propagates the error back through `BasicSolver.GetSpecObjects` and `ClusterSolver.GetSpecObjects`.

The first workspace to create its discoverable Service succeeds normally. The second workspace receives a clear `RoutingInvalid` condition explaining the conflict and which workspace owns the conflicting Service — instead of looping indefinitely.

Re-reconciliation of the same workspace against its own already-existing Services is explicitly allowed (skipped in the conflict check via the workspace ID label), so idempotent reconciliation is unaffected.

## Testing

Four unit tests were added in `controllers/controller/devworkspacerouting/solvers/common_test.go` using a controller-runtime fake client:

- Single workspace with a discoverable endpoint: no error
- Two workspaces with different endpoint names in the same namespace: no error
- Two workspaces with the same endpoint name: second receives `*RoutingInvalid`
- Same workspace re-reconciling after its Service already exists: no false positive

## References

Related upstream issue: `eclipse-che/che#23231`