### PR TITLE
feat: add custom init containers support via DWOC config (CRW-9373)

### DIFF
--- a/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ package v1alpha1
 
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/config/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/config/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -1,0 +1,5146 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: devworkspaceoperatorconfigs.controller.devfile.io
+spec:
+  group: controller.devfile.io
+  names:
+    kind: DevWorkspaceOperatorConfig
+    listKind: DevWorkspaceOperatorConfigList
+    plural: devworkspaceoperatorconfigs
+    shortNames:
+    - dwoc
+    singular: devworkspaceoperatorconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DevWorkspaceOperatorConfig is the Schema for the devworkspaceoperatorconfigs
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          config:
+            description: |-
+              OperatorConfiguration defines configuration options for the DevWorkspace
+              Operator.
+            properties:
+              enableExperimentalFeatures:
+                description: |-
+                  EnableExperimentalFeatures turns on in-development features of the controller.
+                  This option should generally not be enabled, as any capabilites are subject
+                  to removal without notice.
+                type: boolean
+              routing:
+                description: Routing defines configuration options related to DevWorkspace
+                  networking
+                properties:
+                  clusterHostSuffix:
+                    description: |-
+                      ClusterHostSuffix is the hostname suffix to be used for DevWorkspace endpoints.
+                      On OpenShift, the DevWorkspace Operator will attempt to determine the appropriate
+                      value automatically. Must be specified on Kubernetes.
+                    type: string
+                  defaultRoutingClass:
+                    description: |-
+                      DefaultRoutingClass specifies the routingClass to be used when a DevWorkspace
+                      specifies an empty `.spec.routingClass`. Supported routingClasses can be defined
+                      in other controllers. If not specified, the default value of "basic" is used.
+                    type: string
+                  proxyConfig:
+                    description: |-
+                      ProxyConfig defines the proxy settings that should be used for all DevWorkspaces.
+                      These values are propagated to workspace containers as environment variables.
+
+                      On OpenShift, the operator automatically reads values from the "cluster" proxies.config.openshift.io
+                      object and this value only needs to be set to override those defaults. Values for httpProxy
+                      and httpsProxy override the cluster configuration directly. Entries for noProxy are merged
+                      with the noProxy values in the cluster configuration. To ignore automatically read values from the cluster,
+                      set values in fields to the empty string ("")
+
+                      Changes to the proxy configuration are detected by the DevWorkspace Operator and propagated to
+                      DevWorkspaces. However, changing the proxy configuration for the DevWorkspace Operator itself
+                      requires restarting the controller deployment.
+                    properties:
+                      httpProxy:
+                        description: |-
+                          HttpProxy is the URL of the proxy for HTTP requests, in the format http://USERNAME:PASSWORD@SERVER:PORT/. To ignore
+                          automatically detected proxy settings for the cluster, set this field to an empty string ("")
+                        type: string
+                      httpsProxy:
+                        description: |-
+                          HttpsProxy is the URL of the proxy for HTTPS requests, in the format http://USERNAME:PASSWORD@SERVER:PORT/. To ignore
+                          automatically detected proxy settings for the cluster, set this field to an empty string ("")
+                        type: string
+                      noProxy:
+                        description: |-
+                          NoProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used. Ignored
+                          when HttpProxy and HttpsProxy are unset. To ignore automatically detected proxy settings for the cluster, set this
+                          field to an empty string ("")
+                        type: string
+                    type: object
+                  tlsCertificateConfigmapRef:
+                    description: |-
+                      TLSCertificateConfigmapRef defines the name and namespace of the configmap with a certificate to inject into the
+                      HTTP client.
+                    properties:
+                      name:
+                        description: Name is the name of the configmap
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the configmap
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                type: object
+              webhook:
+                description: |-
+                  Webhook defines configuration options for the DevWorkspace Webhook Server.
+                  Note: In order for changes made to the webhook configuration to take effect:
+
+                  - The changes must be made in the global DevWorkspaceOperatorConfig, which has the
+                    name 'devworkspace-operator-config' and exists in the same namespace where the
+                    DevWorkspaceOperator is deployed.
+
+                  - The devworkspace-controller-manager pod must be terminated and recreated for the
+                    DevWorkspace Webhook Server deployment to be updated.
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      NodeSelector defines the map of Kubernetes nodeSelectors to apply to the DevWorkspace Webhook
+                      Server pod(s).
+                      No NodeSelectors are added by default.
+                    type: object
+                  replicas:
+                    default: 2
+                    description: |-
+                      Replicas defines the number of desired DevWorkspace Webhook Server pods.
+                      Defaults to 2.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  tolerations:
+                    description: |-
+                      Tolerations defines the array of Kubernetes pod tolerations to apply to the DevWorkspace Webhook
+                      Server pod(s).
+                      No Tolerations are added by default.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              workspace:
+                description: |-
+                  Workspace defines configuration options related to how DevWorkspaces are
+                  managed
+                properties:
+                  backupCronJob:
+                    description: BackupCronJobConfig defines configuration options
+                      for a cron job that automatically backs up workspace PVCs.
+                    properties:
+                      backoffLimit:
+                        default: 1
+                        description: |-
+                          BackoffLimit specifies the number of retries before marking a backup job as failed.
+                          Defaults to 1 if not specified.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      enable:
+                        description: |-
+                          Enable determines whether backup CronJobs should be created for workspace PVCs.
+                          Defaults to false if not specified.
+                        type: boolean
+                      oras:
+                        description: |-
+                          OrasConfig defines additional configuration options for the oras CLI used to
+                          push and pull backup images.
+                        properties:
+                          extraArgs:
+                            description: ExtraArgs are additional arguments passed
+                              to the oras CLI
+                            type: string
+                        type: object
+                      registry:
+                        description: RegistryConfig defines the registry configuration
+                          where backup images are stored.
+                        properties:
+                          authSecret:
+                            description: |-
+                              AuthSecret is the name of a Kubernetes secret of
+                              type kubernetes.io/dockerconfigjson.
+                              The secret is expected to be in the same namespace the workspace is running in.
+                              If secret is not found in the workspace namespace, the operator will look for the secret
+                              in the namespace where the operator is running in.
+                              as the DevWorkspaceOperatorCongfig.
+                              The secret must contain "controller.devfile.io/watch-secret=true" label so that it can be
+                              recognized by the operator.
+                            type: string
+                          path:
+                            description: |-
+                              A registry where backup images are stored. Images are stored
+                              in {path}/${DEVWORKSPACE_NAMESPACE}/${DEVWORKSPACE_NAME}:latest
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      schedule:
+                        default: 0 0 1 * *
+                        description: |-
+                          Schedule specifies the cron schedule for the backup cron job.
+                          For example, "0 1 * * *" runs daily at 1 AM.
+                        type: string
+                    required:
+                    - registry
+                    type: object
+                  cleanupCronJob:
+                    description: CleanupCronJobConfig defines configuration options
+                      for a cron job that automatically cleans up stale DevWorkspaces.
+                    properties:
+                      dryRun:
+                        description: |-
+                          DryRun determines whether the cleanup cron job should be run in dry-run mode.
+                          If set to true, the cron job will not delete any DevWorkspaces, but will log the DevWorkspaces that would have been deleted.
+                          Defaults to false if not specified.
+                        type: boolean
+                      enable:
+                        description: |-
+                          Enable determines whether the cleanup cron job is enabled.
+                          Defaults to false if not specified.
+                        type: boolean
+                      retainTime:
+                        default: 2592000
+                        description: |-
+                          RetainTime specifies the minimum time (in seconds) since a DevWorkspace was last started before it is considered stale and eligible for cleanup.
+                          For example, a value of 2592000 (30 days) would mean that any DevWorkspace that has not been started in the last 30 days will be deleted.
+                          Defaults to 2592000 seconds (30 days) if not specified.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      schedule:
+                        default: 0 0 1 * *
+                        description: Schedule specifies the cron schedule for the
+                          cleanup cron job.
+                        type: string
+                    type: object
+                  cleanupOnStop:
+                    description: |-
+                      CleanupOnStop governs how the Operator handles stopped DevWorkspaces. If set to
+                      true, additional resources associated with a DevWorkspace (e.g. services, deployments,
+                      configmaps, etc.) will be removed from the cluster when a DevWorkspace has
+                      .spec.started = false. If set to false, resources will be scaled down (e.g. deployments
+                      but the objects will be left on the cluster). The default value is false.
+                    type: boolean
+                  containerResourceCaps:
+                    description: |-
+                      ContainerResourceCaps defines the maximum resource requirements enforced for workspace
+                      containers. If a container specifies limits or requests that exceed these values, they
+                      will be capped at the maximum. Note: Caps only apply when resources are already specified
+                      on a container. For containers without resource specifications, use DefaultContainerResources
+                      instead. These resource caps do not apply to initContainers or the projectClone container.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  containerSecurityContext:
+                    description: |-
+                      ContainerSecurityContext overrides the default ContainerSecurityContext used for all
+                      workspace-related containers created by the DevWorkspace Operator. If set, defined
+                      values are merged into the default configuration
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                          overrides the pod's appArmorProfile.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile loaded on the node that should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must match the loaded name of the profile.
+                              Must be set if and only if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of AppArmor profile will be applied.
+                              Valid options are:
+                                Localhost - a profile pre-loaded on the node.
+                                RuntimeDefault - the container runtime's default profile.
+                                Unconfined - no AppArmor enforcement.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default value is Default which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  defaultContainerResources:
+                    description: |-
+                      DefaultContainerResources defines the resource requirements (memory/cpu limit/request) used for
+                      container components that do not define limits or requests. In order to not set a field by default,
+                      the value "0" should be used. By default, the memory limit is 256Mi and the memory request is 128Mi.
+                      No CPU limit or request is added by default.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  defaultStorageSize:
+                    description: |-
+                      DefaultStorageSize defines an optional struct with fields to specify the sizes of Persistent Volume Claims for storage
+                      classes used by DevWorkspaces.
+                    properties:
+                      common:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The default Persistent Volume Claim size for the "common" storage class.
+                          Note that the "async" storage class also uses the PVC size set for the "common" storage class.
+                          If not specified, the "common" and "async" Persistent Volume Claim sizes are set to 10Gi
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      perWorkspace:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The default Persistent Volume Claim size for the "per-workspace" storage class.
+                          If not specified, the "per-workspace" Persistent Volume Claim size is set to 10Gi
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  defaultTemplate:
+                    description: |-
+                      DefaultTemplate defines an optional DevWorkspace Spec Template which gets applied to the workspace
+                      if the workspace's Template Spec Components are not defined. The DefaultTemplate will overwrite the existing
+                      Template Spec, with the exception of Projects (if any are defined).
+                    properties:
+                      attributes:
+                        description: Map of implementation-dependant free-form YAML
+                          attributes.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      commands:
+                        description: Predefined, ready-to-use, devworkspace-related
+                          commands
+                        items:
+                          properties:
+                            apply:
+                              description: |-
+                                Command that consists in applying a given component definition,
+                                typically bound to a devworkspace event.
+
+                                For example, when an `apply` command is bound to a `preStart` event,
+                                and references a `container` component, it will start the container as a
+                                K8S initContainer in the devworkspace POD, unless the component has its
+                                `dedicatedPod` field set to `true`.
+
+                                When no `apply` command exist for a given component,
+                                it is assumed the component will be applied at devworkspace start
+                                by default, unless `deployByDefault` for that component is set to false.
+                              properties:
+                                component:
+                                  description: Describes component that will be applied
+                                  type: string
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: |-
+                                    Optional label that provides a label for this command
+                                    to be used in Editor UI menus for example
+                                  type: string
+                              required:
+                              - component
+                              type: object
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            commandType:
+                              description: Type of devworkspace command
+                              enum:
+                              - Exec
+                              - Apply
+                              - Composite
+                              - Custom
+                              type: string
+                            composite:
+                              description: |-
+                                Composite command that allows executing several sub-commands
+                                either sequentially or concurrently
+                              properties:
+                                commands:
+                                  description: The commands that comprise this composite
+                                    command
+                                  items:
+                                    type: string
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: |-
+                                    Optional label that provides a label for this command
+                                    to be used in Editor UI menus for example
+                                  type: string
+                                parallel:
+                                  description: Indicates if the sub-commands should
+                                    be executed concurrently
+                                  type: boolean
+                              type: object
+                            custom:
+                              description: |-
+                                Custom command whose logic is implementation-dependant
+                                and should be provided by the user
+                                possibly through some dedicated plugin
+                              properties:
+                                commandClass:
+                                  description: |-
+                                    Class of command that the associated implementation component
+                                    should use to process this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: |-
+                                    Additional free-form configuration for this custom command
+                                    that the implementation component will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: |-
+                                    Optional label that provides a label for this command
+                                    to be used in Editor UI menus for example
+                                  type: string
+                              required:
+                              - commandClass
+                              - embeddedResource
+                              type: object
+                            exec:
+                              description: CLI Command executed in an existing component
+                                container
+                              properties:
+                                commandLine:
+                                  description: |-
+                                    The actual command-line string
+
+                                    Special variables that can be used:
+
+                                     - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
+
+                                     - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+                                  type: string
+                                component:
+                                  description: Describes component to which given
+                                    action relates
+                                  type: string
+                                env:
+                                  description: |-
+                                    Optional list of environment variables that have to be set
+                                    before running the command
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                hotReloadCapable:
+                                  description: |-
+                                    Specify whether the command is restarted or not when the source code changes.
+                                    If set to `true` the command won't be restarted.
+                                    A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again.
+                                    This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`.
+
+                                    Default value is `false`
+                                  type: boolean
+                                label:
+                                  description: |-
+                                    Optional label that provides a label for this command
+                                    to be used in Editor UI menus for example
+                                  type: string
+                                workingDir:
+                                  description: |-
+                                    Working directory where the command should be executed
+
+                                    Special variables that can be used:
+
+                                     - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
+
+                                     - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+                                  type: string
+                              required:
+                              - commandLine
+                              - component
+                              type: object
+                            id:
+                              description: |-
+                                Mandatory identifier that allows referencing
+                                this command in composite commands, from
+                                a parent, or in events.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                          - id
+                          type: object
+                        type: array
+                      components:
+                        description: |-
+                          List of the devworkspace components, such as editor and plugins,
+                          user-provided containers, or other types of components
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            componentType:
+                              description: Type of component
+                              enum:
+                              - Container
+                              - Kubernetes
+                              - Openshift
+                              - Volume
+                              - Image
+                              - Plugin
+                              - Custom
+                              type: string
+                            container:
+                              description: Allows adding and configuring devworkspace-related
+                                containers
+                              properties:
+                                annotation:
+                                  description: Annotations that should be added to
+                                    specific resources for this container
+                                  properties:
+                                    deployment:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to deployment
+                                      type: object
+                                    service:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to service
+                                      type: object
+                                  type: object
+                                args:
+                                  description: |-
+                                    The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.
+
+                                    Defaults to an empty array, meaning use whatever is defined in the image.
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  description: |-
+                                    The command to run in the dockerimage component instead of the default one provided in the image.
+
+                                    Defaults to an empty array, meaning use whatever is defined in the image.
+                                  items:
+                                    type: string
+                                  type: array
+                                cpuLimit:
+                                  type: string
+                                cpuRequest:
+                                  type: string
+                                dedicatedPod:
+                                  description: |-
+                                    Specify if a container should run in its own separated pod,
+                                    instead of running as part of the main development environment pod.
+
+                                    Default value is `false`
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: |-
+                                          Map of implementation-dependant string-based free-form attributes.
+
+                                          Examples of Che-specific attributes:
+
+                                          - cookiesAuthEnabled: "true" / "false",
+
+                                          - type: "terminal" / "ide" / "ide-dev",
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: |-
+                                          Describes how the endpoint should be exposed on the network.
+
+                                          - `public` means that the endpoint will be exposed on the public network, typically through
+                                          a K8S ingress or an OpenShift route.
+
+                                          - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD,
+                                          typically by K8S services, to be consumed by other elements running
+                                          on the same cloud internal network.
+
+                                          - `none` means that the endpoint will not be exposed and will only be accessible
+                                          inside the main devworkspace POD, on a local address.
+
+                                          Default value is `public`
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: |-
+                                          Describes the application and transport protocols of the traffic that will go through this endpoint.
+
+                                          - `http`: Endpoint will have `http` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `https` when the `secure` field is set to `true`.
+
+                                          - `https`: Endpoint will have `https` traffic, typically on a TCP connection.
+
+                                          - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.
+
+                                          - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.
+
+                                          - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.
+
+                                          - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.
+
+                                          Default value is `http`
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: |-
+                                          Describes whether the endpoint should be secured and protected by some
+                                          authentication process. This requires a protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: |-
+                                          Port number to be used within the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                env:
+                                  description: |-
+                                    Environment variables used in this container.
+
+                                    The following variables are reserved and cannot be overridden via env:
+
+                                     - `$PROJECTS_ROOT`
+
+                                     - `$PROJECT_SOURCE`
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                memoryLimit:
+                                  type: string
+                                memoryRequest:
+                                  type: string
+                                mountSources:
+                                  description: |-
+                                    Toggles whether or not the project source code should
+                                    be mounted in the component.
+
+                                    Defaults to true for all component types except plugins and components that set `dedicatedPod` to true.
+                                  type: boolean
+                                sourceMapping:
+                                  default: /projects
+                                  description: |-
+                                    Optional specification of the path in the container where
+                                    project sources should be transferred/mounted when `mountSources` is `true`.
+                                    When omitted, the default value of /projects is used.
+                                  type: string
+                                volumeMounts:
+                                  description: List of volumes mounts that should
+                                    be mounted is this container.
+                                  items:
+                                    description: Volume that should be mounted to
+                                      a component container
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The volume mount name is the name of an existing `Volume` component.
+                                          If several containers mount the same volume name
+                                          then they will reuse the same volume and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: |-
+                                          The path in the component container where the volume should be mounted.
+                                          If not path is mentioned, default path is the is `/<name>`.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                              required:
+                              - image
+                              type: object
+                            custom:
+                              description: |-
+                                Custom component whose logic is implementation-dependant
+                                and should be provided by the user
+                                possibly through some dedicated controller
+                              properties:
+                                componentClass:
+                                  description: |-
+                                    Class of component that the associated implementation controller
+                                    should use to process this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: |-
+                                    Additional free-form configuration for this custom component
+                                    that the implementation controller will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                              - componentClass
+                              - embeddedResource
+                              type: object
+                            image:
+                              description: Allows specifying the definition of an
+                                image for outer loop builds
+                              properties:
+                                autoBuild:
+                                  description: |-
+                                    Defines if the image should be built during startup.
+
+                                    Default value is `false`
+                                  type: boolean
+                                dockerfile:
+                                  description: Allows specifying dockerfile type build
+                                  properties:
+                                    args:
+                                      description: The arguments to supply to the
+                                        dockerfile build.
+                                      items:
+                                        type: string
+                                      type: array
+                                    buildContext:
+                                      description: Path of source directory to establish
+                                        build context. Defaults to ${PROJECT_SOURCE}
+                                        in the container
+                                      type: string
+                                    devfileRegistry:
+                                      description: Dockerfile's Devfile Registry source
+                                      properties:
+                                        id:
+                                          description: |-
+                                            Id in a devfile registry that contains a Dockerfile. The src in the OCI registry
+                                            required for the Dockerfile build will be downloaded for building the image.
+                                          type: string
+                                        registryUrl:
+                                          description: |-
+                                            Devfile Registry URL to pull the Dockerfile from when using the Devfile Registry as Dockerfile src.
+                                            To ensure the Dockerfile gets resolved consistently in different environments,
+                                            it is recommended to always specify the `devfileRegistryUrl` when `Id` is used.
+                                          type: string
+                                      required:
+                                      - id
+                                      type: object
+                                    git:
+                                      description: Dockerfile's Git source
+                                      properties:
+                                        checkoutFrom:
+                                          description: Defines from what the project
+                                            should be checked out. Required if there
+                                            are more than one remote configured
+                                          properties:
+                                            remote:
+                                              description: The remote name should
+                                                be used as init. Required if there
+                                                are more than one remote configured
+                                              type: string
+                                            revision:
+                                              description: |-
+                                                The revision to checkout from. Should be branch name, tag or commit id.
+                                                Default branch is used if missing or specified revision is not found.
+                                              type: string
+                                          type: object
+                                        fileLocation:
+                                          description: |-
+                                            Location of the Dockerfile in the Git repository when using git as Dockerfile src.
+                                            Defaults to Dockerfile.
+                                          type: string
+                                        remotes:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            The remotes map which should be initialized in the git project.
+                                            Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                                          type: object
+                                      required:
+                                      - remotes
+                                      type: object
+                                    rootRequired:
+                                      description: |-
+                                        Specify if a privileged builder pod is required.
+
+                                        Default value is `false`
+                                      type: boolean
+                                    srcType:
+                                      description: Type of Dockerfile src
+                                      enum:
+                                      - Uri
+                                      - DevfileRegistry
+                                      - Git
+                                      type: string
+                                    uri:
+                                      description: |-
+                                        URI Reference of a Dockerfile.
+                                        It can be a full URL or a relative URI from the current devfile as the base URI.
+                                      type: string
+                                  type: object
+                                imageName:
+                                  description: Name of the image for the resulting
+                                    outerloop build
+                                  type: string
+                                imageType:
+                                  description: Type of image
+                                  enum:
+                                  - Dockerfile
+                                  type: string
+                              required:
+                              - imageName
+                              type: object
+                            kubernetes:
+                              description: |-
+                                Allows importing into the devworkspace the Kubernetes resources
+                                defined in a given manifest. For example this allows reusing the Kubernetes
+                                definitions used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: |-
+                                    Defines if the component should be deployed during startup.
+
+                                    Default value is `false`
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: |-
+                                          Map of implementation-dependant string-based free-form attributes.
+
+                                          Examples of Che-specific attributes:
+
+                                          - cookiesAuthEnabled: "true" / "false",
+
+                                          - type: "terminal" / "ide" / "ide-dev",
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: |-
+                                          Describes how the endpoint should be exposed on the network.
+
+                                          - `public` means that the endpoint will be exposed on the public network, typically through
+                                          a K8S ingress or an OpenShift route.
+
+                                          - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD,
+                                          typically by K8S services, to be consumed by other elements running
+                                          on the same cloud internal network.
+
+                                          - `none` means that the endpoint will not be exposed and will only be accessible
+                                          inside the main devworkspace POD, on a local address.
+
+                                          Default value is `public`
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: |-
+                                          Describes the application and transport protocols of the traffic that will go through this endpoint.
+
+                                          - `http`: Endpoint will have `http` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `https` when the `secure` field is set to `true`.
+
+                                          - `https`: Endpoint will have `https` traffic, typically on a TCP connection.
+
+                                          - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.
+
+                                          - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.
+
+                                          - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.
+
+                                          - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.
+
+                                          Default value is `http`
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: |-
+                                          Describes whether the endpoint should be secured and protected by some
+                                          authentication process. This requires a protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: |-
+                                          Port number to be used within the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            name:
+                              description: |-
+                                Mandatory name that allows referencing the component
+                                from other elements (such as commands) or from an external
+                                devfile that may reference this component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            openshift:
+                              description: |-
+                                Allows importing into the devworkspace the OpenShift resources
+                                defined in a given manifest. For example this allows reusing the OpenShift
+                                definitions used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: |-
+                                    Defines if the component should be deployed during startup.
+
+                                    Default value is `false`
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: |-
+                                          Map of implementation-dependant string-based free-form attributes.
+
+                                          Examples of Che-specific attributes:
+
+                                          - cookiesAuthEnabled: "true" / "false",
+
+                                          - type: "terminal" / "ide" / "ide-dev",
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: |-
+                                          Describes how the endpoint should be exposed on the network.
+
+                                          - `public` means that the endpoint will be exposed on the public network, typically through
+                                          a K8S ingress or an OpenShift route.
+
+                                          - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD,
+                                          typically by K8S services, to be consumed by other elements running
+                                          on the same cloud internal network.
+
+                                          - `none` means that the endpoint will not be exposed and will only be accessible
+                                          inside the main devworkspace POD, on a local address.
+
+                                          Default value is `public`
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: |-
+                                          Describes the application and transport protocols of the traffic that will go through this endpoint.
+
+                                          - `http`: Endpoint will have `http` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `https` when the `secure` field is set to `true`.
+
+                                          - `https`: Endpoint will have `https` traffic, typically on a TCP connection.
+
+                                          - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.
+
+                                          - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.
+
+                                          - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.
+
+                                          - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.
+
+                                          Default value is `http`
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: |-
+                                          Describes whether the endpoint should be secured and protected by some
+                                          authentication process. This requires a protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: |-
+                                          Port number to be used within the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            plugin:
+                              description: |-
+                                Allows importing a plugin.
+
+                                Plugins are mainly imported devfiles that contribute components, commands
+                                and events as a consistent single unit. They are defined in either YAML files
+                                following the devfile syntax,
+                                or as `DevWorkspaceTemplate` Kubernetes Custom Resources
+                              properties:
+                                commands:
+                                  description: |-
+                                    Overrides of commands encapsulated in a parent devfile or a plugin.
+                                    Overriding is done according to K8S strategic merge patch standard rules.
+                                  items:
+                                    properties:
+                                      apply:
+                                        description: |-
+                                          Command that consists in applying a given component definition,
+                                          typically bound to a devworkspace event.
+
+                                          For example, when an `apply` command is bound to a `preStart` event,
+                                          and references a `container` component, it will start the container as a
+                                          K8S initContainer in the devworkspace POD, unless the component has its
+                                          `dedicatedPod` field set to `true`.
+
+                                          When no `apply` command exist for a given component,
+                                          it is assumed the component will be applied at devworkspace start
+                                          by default, unless `deployByDefault` for that component is set to false.
+                                        properties:
+                                          component:
+                                            description: Describes component that
+                                              will be applied
+                                            type: string
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: |-
+                                              Optional label that provides a label for this command
+                                              to be used in Editor UI menus for example
+                                            type: string
+                                        type: object
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      commandType:
+                                        description: Type of devworkspace command
+                                        enum:
+                                        - Exec
+                                        - Apply
+                                        - Composite
+                                        type: string
+                                      composite:
+                                        description: |-
+                                          Composite command that allows executing several sub-commands
+                                          either sequentially or concurrently
+                                        properties:
+                                          commands:
+                                            description: The commands that comprise
+                                              this composite command
+                                            items:
+                                              type: string
+                                            type: array
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: |-
+                                              Optional label that provides a label for this command
+                                              to be used in Editor UI menus for example
+                                            type: string
+                                          parallel:
+                                            description: Indicates if the sub-commands
+                                              should be executed concurrently
+                                            type: boolean
+                                        type: object
+                                      exec:
+                                        description: CLI Command executed in an existing
+                                          component container
+                                        properties:
+                                          commandLine:
+                                            description: |-
+                                              The actual command-line string
+
+                                              Special variables that can be used:
+
+                                               - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
+
+                                               - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+                                            type: string
+                                          component:
+                                            description: Describes component to which
+                                              given action relates
+                                            type: string
+                                          env:
+                                            description: |-
+                                              Optional list of environment variables that have to be set
+                                              before running the command
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          hotReloadCapable:
+                                            description: |-
+                                              Specify whether the command is restarted or not when the source code changes.
+                                              If set to `true` the command won't be restarted.
+                                              A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted.
+                                              A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again.
+                                              This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`.
+
+                                              Default value is `false`
+                                            type: boolean
+                                          label:
+                                            description: |-
+                                              Optional label that provides a label for this command
+                                              to be used in Editor UI menus for example
+                                            type: string
+                                          workingDir:
+                                            description: |-
+                                              Working directory where the command should be executed
+
+                                              Special variables that can be used:
+
+                                               - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
+
+                                               - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+                                            type: string
+                                        type: object
+                                      id:
+                                        description: |-
+                                          Mandatory identifier that allows referencing
+                                          this command in composite commands, from
+                                          a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                    required:
+                                    - id
+                                    type: object
+                                  type: array
+                                components:
+                                  description: |-
+                                    Overrides of components encapsulated in a parent devfile or a plugin.
+                                    Overriding is done according to K8S strategic merge patch standard rules.
+                                  items:
+                                    properties:
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      componentType:
+                                        description: Type of component
+                                        enum:
+                                        - Container
+                                        - Kubernetes
+                                        - Openshift
+                                        - Volume
+                                        - Image
+                                        type: string
+                                      container:
+                                        description: Allows adding and configuring
+                                          devworkspace-related containers
+                                        properties:
+                                          annotation:
+                                            description: Annotations that should be
+                                              added to specific resources for this
+                                              container
+                                            properties:
+                                              deployment:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to deployment
+                                                type: object
+                                              service:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to service
+                                                type: object
+                                            type: object
+                                          args:
+                                            description: |-
+                                              The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.
+
+                                              Defaults to an empty array, meaning use whatever is defined in the image.
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: |-
+                                              The command to run in the dockerimage component instead of the default one provided in the image.
+
+                                              Defaults to an empty array, meaning use whatever is defined in the image.
+                                            items:
+                                              type: string
+                                            type: array
+                                          cpuLimit:
+                                            type: string
+                                          cpuRequest:
+                                            type: string
+                                          dedicatedPod:
+                                            description: |-
+                                              Specify if a container should run in its own separated pod,
+                                              instead of running as part of the main development environment pod.
+
+                                              Default value is `false`
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: |-
+                                                    Map of implementation-dependant string-based free-form attributes.
+
+                                                    Examples of Che-specific attributes:
+
+                                                    - cookiesAuthEnabled: "true" / "false",
+
+                                                    - type: "terminal" / "ide" / "ide-dev",
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: |-
+                                                    Describes how the endpoint should be exposed on the network.
+
+                                                    - `public` means that the endpoint will be exposed on the public network, typically through
+                                                    a K8S ingress or an OpenShift route.
+
+                                                    - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD,
+                                                    typically by K8S services, to be consumed by other elements running
+                                                    on the same cloud internal network.
+
+                                                    - `none` means that the endpoint will not be exposed and will only be accessible
+                                                    inside the main devworkspace POD, on a local address.
+
+                                                    Default value is `public`
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: |-
+                                                    Describes the application and transport protocols of the traffic that will go through this endpoint.
+
+                                                    - `http`: Endpoint will have `http` traffic, typically on a TCP connection.
+                                                    It will be automaticaly promoted to `https` when the `secure` field is set to `true`.
+
+                                                    - `https`: Endpoint will have `https` traffic, typically on a TCP connection.
+
+                                                    - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection.
+                                                    It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.
+
+                                                    - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.
+
+                                                    - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.
+
+                                                    - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.
+
+                                                    Default value is `http`
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: |-
+                                                    Describes whether the endpoint should be secured and protected by some
+                                                    authentication process. This requires a protocol of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: |-
+                                                    Port number to be used within the container component. The same port cannot
+                                                    be used by two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          env:
+                                            description: |-
+                                              Environment variables used in this container.
+
+                                              The following variables are reserved and cannot be overridden via env:
+
+                                               - `$PROJECTS_ROOT`
+
+                                               - `$PROJECT_SOURCE`
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          image:
+                                            type: string
+                                          memoryLimit:
+                                            type: string
+                                          memoryRequest:
+                                            type: string
+                                          mountSources:
+                                            description: |-
+                                              Toggles whether or not the project source code should
+                                              be mounted in the component.
+
+                                              Defaults to true for all component types except plugins and components that set `dedicatedPod` to true.
+                                            type: boolean
+                                          sourceMapping:
+                                            description: |-
+                                              Optional specification of the path in the container where
+                                              project sources should be transferred/mounted when `mountSources` is `true`.
+                                              When omitted, the default value of /projects is used.
+                                            type: string
+                                          volumeMounts:
+                                            description: List of volumes mounts that
+                                              should be mounted is this container.
+                                            items:
+                                              description: Volume that should be mounted
+                                                to a component container
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The volume mount name is the name of an existing `Volume` component.
+                                                    If several containers mount the same volume name
+                                                    then they will reuse the same volume and will be able to access to the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: |-
+                                                    The path in the component container where the volume should be mounted.
+                                                    If not path is mentioned, default path is the is `/<name>`.
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                        type: object
+                                      image:
+                                        description: Allows specifying the definition
+                                          of an image for outer loop builds
+                                        properties:
+                                          autoBuild:
+                                            description: |-
+                                              Defines if the image should be built during startup.
+
+                                              Default value is `false`
+                                            type: boolean
+                                          dockerfile:
+                                            description: Allows specifying dockerfile
+                                              type build
+                                            properties:
+                                              args:
+                                                description: The arguments to supply
+                                                  to the dockerfile build.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              buildContext:
+                                                description: Path of source directory
+                                                  to establish build context. Defaults
+                                                  to ${PROJECT_SOURCE} in the container
+                                                type: string
+                                              devfileRegistry:
+                                                description: Dockerfile's Devfile
+                                                  Registry source
+                                                properties:
+                                                  id:
+                                                    description: |-
+                                                      Id in a devfile registry that contains a Dockerfile. The src in the OCI registry
+                                                      required for the Dockerfile build will be downloaded for building the image.
+                                                    type: string
+                                                  registryUrl:
+                                                    description: |-
+                                                      Devfile Registry URL to pull the Dockerfile from when using the Devfile Registry as Dockerfile src.
+                                                      To ensure the Dockerfile gets resolved consistently in different environments,
+                                                      it is recommended to always specify the `devfileRegistryUrl` when `Id` is used.
+                                                    type: string
+                                                type: object
+                                              git:
+                                                description: Dockerfile's Git source
+                                                properties:
+                                                  checkoutFrom:
+                                                    description: Defines from what
+                                                      the project should be checked
+                                                      out. Required if there are more
+                                                      than one remote configured
+                                                    properties:
+                                                      remote:
+                                                        description: The remote name
+                                                          should be used as init.
+                                                          Required if there are more
+                                                          than one remote configured
+                                                        type: string
+                                                      revision:
+                                                        description: |-
+                                                          The revision to checkout from. Should be branch name, tag or commit id.
+                                                          Default branch is used if missing or specified revision is not found.
+                                                        type: string
+                                                    type: object
+                                                  fileLocation:
+                                                    description: |-
+                                                      Location of the Dockerfile in the Git repository when using git as Dockerfile src.
+                                                      Defaults to Dockerfile.
+                                                    type: string
+                                                  remotes:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      The remotes map which should be initialized in the git project.
+                                                      Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                                                    type: object
+                                                type: object
+                                              rootRequired:
+                                                description: |-
+                                                  Specify if a privileged builder pod is required.
+
+                                                  Default value is `false`
+                                                type: boolean
+                                              srcType:
+                                                description: Type of Dockerfile src
+                                                enum:
+                                                - Uri
+                                                - DevfileRegistry
+                                                - Git
+                                                type: string
+                                              uri:
+                                                description: |-
+                                                  URI Reference of a Dockerfile.
+                                                  It can be a full URL or a relative URI from the current devfile as the base URI.
+                                                type: string
+                                            type: object
+                                          imageName:
+                                            description: Name of the image for the
+                                              resulting outerloop build
+                                            type: string
+                                          imageType:
+                                            description: Type of image
+                                            enum:
+                                            - Dockerfile
+                                            - AutoBuild
+                                            type: string
+                                        type: object
+                                      kubernetes:
+                                        description: |-
+                                          Allows importing into the devworkspace the Kubernetes resources
+                                          defined in a given manifest. For example this allows reusing the Kubernetes
+                                          definitions used to deploy some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: |-
+                                              Defines if the component should be deployed during startup.
+
+                                              Default value is `false`
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: |-
+                                                    Map of implementation-dependant string-based free-form attributes.
+
+                                                    Examples of Che-specific attributes:
+
+                                                    - cookiesAuthEnabled: "true" / "false",
+
+                                                    - type: "terminal" / "ide" / "ide-dev",
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: |-
+                                                    Describes how the endpoint should be exposed on the network.
+
+                                                    - `public` means that the endpoint will be exposed on the public network, typically through
+                                                    a K8S ingress or an OpenShift route.
+
+                                                    - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD,
+                                                    typically by K8S services, to be consumed by other elements running
+                                                    on the same cloud internal network.
+
+                                                    - `none` means that the endpoint will not be exposed and will only be accessible
+                                                    inside the main devworkspace POD, on a local address.
+
+                                                    Default value is `public`
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: |-
+                                                    Describes the application and transport protocols of the traffic that will go through this endpoint.
+
+                                                    - `http`: Endpoint will have `http` traffic, typically on a TCP connection.
+                                                    It will be automaticaly promoted to `https` when the `secure` field is set to `true`.
+
+                                                    - `https`: Endpoint will have `https` traffic, typically on a TCP connection.
+
+                                                    - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection.
+                                                    It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.
+
+                                                    - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.
+
+                                                    - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.
+
+                                                    - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.
+
+                                                    Default value is `http`
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: |-
+                                                    Describes whether the endpoint should be secured and protected by some
+                                                    authentication process. This requires a protocol of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: |-
+                                                    Port number to be used within the container component. The same port cannot
+                                                    be used by two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched
+                                              from a uri.
+                                            type: string
+                                        type: object
+                                      name:
+                                        description: |-
+                                          Mandatory name that allows referencing the component
+                                          from other elements (such as commands) or from an external
+                                          devfile that may reference this component through a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      openshift:
+                                        description: |-
+                                          Allows importing into the devworkspace the OpenShift resources
+                                          defined in a given manifest. For example this allows reusing the OpenShift
+                                          definitions used to deploy some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: |-
+                                              Defines if the component should be deployed during startup.
+
+                                              Default value is `false`
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: |-
+                                                    Map of implementation-dependant string-based free-form attributes.
+
+                                                    Examples of Che-specific attributes:
+
+                                                    - cookiesAuthEnabled: "true" / "false",
+
+                                                    - type: "terminal" / "ide" / "ide-dev",
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: |-
+                                                    Describes how the endpoint should be exposed on the network.
+
+                                                    - `public` means that the endpoint will be exposed on the public network, typically through
+                                                    a K8S ingress or an OpenShift route.
+
+                                                    - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD,
+                                                    typically by K8S services, to be consumed by other elements running
+                                                    on the same cloud internal network.
+
+                                                    - `none` means that the endpoint will not be exposed and will only be accessible
+                                                    inside the main devworkspace POD, on a local address.
+
+                                                    Default value is `public`
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: |-
+                                                    Describes the application and transport protocols of the traffic that will go through this endpoint.
+
+                                                    - `http`: Endpoint will have `http` traffic, typically on a TCP connection.
+                                                    It will be automaticaly promoted to `https` when the `secure` field is set to `true`.
+
+                                                    - `https`: Endpoint will have `https` traffic, typically on a TCP connection.
+
+                                                    - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection.
+                                                    It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.
+
+                                                    - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.
+
+                                                    - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.
+
+                                                    - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.
+
+                                                    Default value is `http`
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: |-
+                                                    Describes whether the endpoint should be secured and protected by some
+                                                    authentication process. This requires a protocol of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: |-
+                                                    Port number to be used within the container component. The same port cannot
+                                                    be used by two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched
+                                              from a uri.
+                                            type: string
+                                        type: object
+                                      volume:
+                                        description: |-
+                                          Allows specifying the definition of a volume
+                                          shared by several other components
+                                        properties:
+                                          ephemeral:
+                                            description: |-
+                                              Ephemeral volumes are not stored persistently across restarts. Defaults
+                                              to false
+                                            type: boolean
+                                          size:
+                                            description: Size of the volume
+                                            type: string
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                id:
+                                  description: Id in a registry that contains a Devfile
+                                    yaml file
+                                  type: string
+                                importReferenceType:
+                                  description: type of location from where the referenced
+                                    template structure should be retrieved
+                                  enum:
+                                  - Uri
+                                  - Id
+                                  - Kubernetes
+                                  type: string
+                                kubernetes:
+                                  description: Reference to a Kubernetes CRD of type
+                                    DevWorkspaceTemplate
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                registryUrl:
+                                  description: |-
+                                    Registry URL to pull the parent devfile from when using id in the parent reference.
+                                    To ensure the parent devfile gets resolved consistently in different environments,
+                                    it is recommended to always specify the `registryUrl` when `id` is used.
+                                  type: string
+                                uri:
+                                  description: |-
+                                    URI Reference of a parent devfile YAML file.
+                                    It can be a full URL or a relative URI with the current devfile as the base URI.
+                                  type: string
+                                version:
+                                  description: |-
+                                    Specific stack/sample version to pull the parent devfile from, when using id in the parent reference.
+                                    To specify `version`, `id` must be defined and used as the import reference source.
+                                    `version` can be either a specific stack version, or `latest`.
+                                    If no `version` specified, default version will be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                                  type: string
+                              type: object
+                            volume:
+                              description: |-
+                                Allows specifying the definition of a volume
+                                shared by several other components
+                              properties:
+                                ephemeral:
+                                  description: |-
+                                    Ephemeral volumes are not stored persistently across restarts. Defaults
+                                    to false
+                                  type: boolean
+                                size:
+                                  description: Size of the volume
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      dependentProjects:
+                        description: Additional projects related to the main project
+                          in the devfile, contianing names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: |-
+                                        The revision to checkout from. Should be branch name, tag or commit id.
+                                        Default branch is used if missing or specified revision is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    The remotes map which should be initialized in the git project.
+                                    Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              required:
+                              - location
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      events:
+                        description: |-
+                          Bindings of commands to events.
+                          Each command is referred-to by its name.
+                        properties:
+                          postStart:
+                            description: |-
+                              IDs of commands that should be executed after the devworkspace is completely started.
+                              In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning.
+                              This means that those commands are not triggered until the user opens the IDE in his browser.
+                            items:
+                              type: string
+                            type: array
+                          postStop:
+                            description: IDs of commands that should be executed after
+                              stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                          preStart:
+                            description: |-
+                              IDs of commands that should be executed before the devworkspace start.
+                              Kubernetes-wise, these commands would typically be executed in init containers of the devworkspace POD.
+                            items:
+                              type: string
+                            type: array
+                          preStop:
+                            description: IDs of commands that should be executed before
+                              stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      projects:
+                        description: Projects worked on in the devworkspace, containing
+                          names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: |-
+                                        The revision to checkout from. Should be branch name, tag or commit id.
+                                        Default branch is used if missing or specified revision is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    The remotes map which should be initialized in the git project.
+                                    Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              required:
+                              - location
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      starterProjects:
+                        description: StarterProjects is a project that can be used
+                          as a starting point when bootstrapping new projects
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            description:
+                              description: Description of a starter project
+                              type: string
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: |-
+                                        The revision to checkout from. Should be branch name, tag or commit id.
+                                        Default branch is used if missing or specified revision is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    The remotes map which should be initialized in the git project.
+                                    Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            subDir:
+                              description: Sub-directory from a starter project to
+                                be used as root for starter project.
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              required:
+                              - location
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      variables:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of key-value variables used for string replacement in the devfile. Values can be referenced via {{variable-key}}
+                          to replace the corresponding value in string fields in the devfile. Replacement cannot be used for
+
+                           - schemaVersion, metadata, parent source
+
+                           - element identifiers, e.g. command id, component name, endpoint name, project name
+
+                           - references to identifiers, e.g. in events, a command's component, container's volume mount name
+
+                           - string enums, e.g. command group kind, endpoint exposure
+                        type: object
+                    type: object
+                  deploymentStrategy:
+                    description: |-
+                      DeploymentStrategy defines the deployment strategy to use to replace existing DevWorkspace pods
+                      with new ones. The available deployment stragies are "Recreate" and "RollingUpdate".
+                      With the "Recreate" deployment strategy, the existing workspace pod is killed before the new one is created.
+                      With the "RollingUpdate" deployment strategy, a new workspace pod is created and the existing workspace pod is deleted
+                      only when the new workspace pod is in a ready state.
+                      If not specified, the default "Recreate" deployment strategy is used.
+                    enum:
+                    - Recreate
+                    - RollingUpdate
+                    type: string
+                  hostUsers:
+                    description: |-
+                      Controls whether the Pod uses the host's user namespace.
+                      If true (or omitted), the Pod runs in the host's user namespace.
+                      If false, a new user namespace is created for the Pod.
+                      This field is only used when the UserNamespacesSupport feature is enabled.
+                      If the feature is disabled, setting this field may cause an endless workspace start loop.
+                    type: boolean
+                  idleTimeout:
+                    description: |-
+                      IdleTimeout determines how long a workspace should sit idle before being
+                      automatically scaled down. Proper functionality of this configuration property
+                      requires support in the workspace being started. If not specified, the default
+                      value of "15m" is used.
+                    type: string
+                  ignoredUnrecoverableEvents:
+                    description: |-
+                      IgnoredUnrecoverableEvents defines a list of Kubernetes event names that should
+                      be ignored when deciding to fail a DevWorkspace startup. This option should be used
+                      if a transient cluster issue is triggering false-positives (for example, if
+                      the cluster occasionally encounters FailedScheduling events). Events listed
+                      here will not trigger DevWorkspace failures.
+                    items:
+                      type: string
+                    type: array
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy defines the imagePullPolicy used for containers in a DevWorkspace
+                      For additional information, see Kubernetes documentation for imagePullPolicy. If
+                      not specified, the default value of "Always" is used.
+                    enum:
+                    - IfNotPresent
+                    - Always
+                    - Never
+                    type: string
+                  initContainers:
+                    description: |-
+                      InitContainers defines a list of Kubernetes init containers that are automatically injected into all workspace pods.
+                      Typical uses cases include injecting organization tools/configs, initializing persistent home, etc.
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: |-
+                            Arguments to the entrypoint.
+                            The container image's CMD is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                            cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                            produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Cannot be updated.
+                            More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        command:
+                          description: |-
+                            Entrypoint array. Not executed within a shell.
+                            The container image's ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                            cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                            produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Cannot be updated.
+                            More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        env:
+                          description: |-
+                            List of environment variables to set in the container.
+                            Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
+                                type: string
+                              value:
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previously defined environment variables in the container and
+                                  any service environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                  "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                  Escaped references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    description: |-
+                                      Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                      spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: |-
+                            List of sources to populate environment variables in the container.
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
+                            sources, the value associated with the last source will take precedence.
+                            Values defined by an Env with a duplicate key will take precedence.
+                            Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps or Secrets
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              prefix:
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        image:
+                          description: |-
+                            Container image name.
+                            More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management to default or override
+                            container images in workload controllers like Deployments and StatefulSets.
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy.
+                            One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                          type: string
+                        lifecycle:
+                          description: |-
+                            Actions that the management system should take in response to container lifecycle events.
+                            Cannot be updated.
+                          properties:
+                            postStart:
+                              description: |-
+                                PostStart is called immediately after a container is created. If the handler fails,
+                                the container is terminated and restarted according to its restart policy.
+                                Other management of the container blocks until the hook completes.
+                                More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents a duration that the
+                                    container should sleep.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
+                                  type: object
+                                tcpSocket:
+                                  description: |-
+                                    Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                    for backward compatibility. There is no validation of this field and
+                                    lifecycle hooks will fail at runtime when it is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: |-
+                                PreStop is called immediately before a container is terminated due to an
+                                API request or management event such as liveness/startup probe failure,
+                                preemption, resource contention, etc. The handler is not called if the
+                                container crashes or exits. The Pod's termination grace period countdown begins before the
+                                PreStop hook is executed. Regardless of the outcome of the handler, the
+                                container will eventually terminate within the Pod's termination grace
+                                period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                or until the termination grace period is reached.
+                                More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents a duration that the
+                                    container should sleep.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
+                                  type: object
+                                tcpSocket:
+                                  description: |-
+                                    Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                    for backward compatibility. There is no validation of this field and
+                                    lifecycle hooks will fail at runtime when it is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            stopSignal:
+                              description: |-
+                                StopSignal defines which signal will be sent to a container when it is being stopped.
+                                If not specified, the default is defined by the container runtime in use.
+                                StopSignal can only be set for Pods with a non-empty .spec.os.name
+                              type: string
+                          type: object
+                        livenessProbe:
+                          description: |-
+                            Periodic probe of container liveness.
+                            Container will be restarted if the probe fails.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in
+                                the container.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            failureThreshold:
+                              description: |-
+                                Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  default: ""
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest
+                                    (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: |-
+                                Number of seconds after the container has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: |-
+                                How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: |-
+                                Minimum consecutive successes for the probe to be considered successful after having failed.
+                                Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP
+                                port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                value overrides the value provided by the pod spec.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: |-
+                                Number of seconds after which the probe times out.
+                                Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: |-
+                            Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: |-
+                            List of ports to expose from the container. Not specifying a port here
+                            DOES NOT prevent that port from being exposed. Any port which is
+                            listening on the default "0.0.0.0" address inside a container will be
+                            accessible from the network.
+                            Modifying this array with strategic merge patch may corrupt the data.
+                            For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: |-
+                                  Number of port to expose on the pod's IP address.
+                                  This must be a valid port number, 0 < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: |-
+                                  Number of port to expose on the host.
+                                  If specified, this must be a valid port number, 0 < x < 65536.
+                                  If HostNetwork is specified, this must match ContainerPort.
+                                  Most containers do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: |-
+                                  If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                  named port in a pod must have a unique name. Name for the port that can be
+                                  referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP.
+                                  Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: |-
+                            Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the probe fails.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in
+                                the container.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            failureThreshold:
+                              description: |-
+                                Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  default: ""
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest
+                                    (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: |-
+                                Number of seconds after the container has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: |-
+                                How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: |-
+                                Minimum consecutive successes for the probe to be considered successful after having failed.
+                                Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP
+                                port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                value overrides the value provided by the pod spec.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: |-
+                                Number of seconds after which the probe times out.
+                                Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                          type: object
+                        resizePolicy:
+                          description: |-
+                            Resources resize policy for the container.
+                            This field cannot be set on ephemeral containers.
+                          items:
+                            description: ContainerResizePolicy represents resource
+                              resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: |-
+                                  Name of the resource to which this resource resize policy applies.
+                                  Supported values: cpu, memory.
+                                type: string
+                              restartPolicy:
+                                description: |-
+                                  Restart policy to apply when specified resource is resized.
+                                  If not specified, it defaults to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Compute Resources required by this container.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+                                This field depends on the
+                                DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                  request:
+                                    description: |-
+                                      Request is the name chosen for a request in the referenced claim.
+                                      If empty, everything from the claim is made available, otherwise
+                                      only the result of this request.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                        restartPolicy:
+                          description: |-
+                            RestartPolicy defines the restart behavior of individual containers in a pod.
+                            This overrides the pod-level restart policy. When this field is not specified,
+                            the restart behavior is defined by the Pod's restart policy and the container type.
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
+                            this init container will be continually restarted on
+                            exit until all regular containers have terminated. Once all regular
+                            containers have completed, all init containers with restartPolicy "Always"
+                            will be shut down. This lifecycle differs from normal init containers and
+                            is often referred to as a "sidecar" container. Although this init
+                            container still starts in the init container sequence, it does not wait
+                            for the container to complete before proceeding to the next init
+                            container. Instead, the next init container starts immediately after this
+                            init container is started, or after any startupProbe has successfully
+                            completed.
+                          type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        securityContext:
+                          description: |-
+                            SecurityContext defines the security options the container should be run with.
+                            If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: |-
+                                AllowPrivilegeEscalation controls whether a process can gain more
+                                privileges than its parent process. This bool directly controls if
+                                the no_new_privs flag will be set on the container process.
+                                AllowPrivilegeEscalation is true always when the container is:
+                                1) run as Privileged
+                                2) has CAP_SYS_ADMIN
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            appArmorProfile:
+                              description: |-
+                                appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                overrides the pod's appArmorProfile.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile loaded on the node that should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must match the loaded name of the profile.
+                                    Must be set if and only if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of AppArmor profile will be applied.
+                                    Valid options are:
+                                      Localhost - a profile pre-loaded on the node.
+                                      RuntimeDefault - the container runtime's default profile.
+                                      Unconfined - no AppArmor enforcement.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            capabilities:
+                              description: |-
+                                The capabilities to add/drop when running containers.
+                                Defaults to the default set of capabilities granted by the container runtime.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities
+                                      type
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities
+                                      type
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            privileged:
+                              description: |-
+                                Run container in privileged mode.
+                                Processes in privileged containers are essentially equivalent to root on the host.
+                                Defaults to false.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: |-
+                                procMount denotes the type of proc mount to use for the containers.
+                                The default value is Default which uses the container runtime defaults for
+                                readonly paths and masked paths.
+                                This requires the ProcMountType feature flag to be enabled.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: |-
+                                Whether this container has a read-only root filesystem.
+                                Default is false.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: |-
+                                The GID to run the entrypoint of the container process.
+                                Uses runtime default if unset.
+                                May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: |-
+                                Indicates that the container must run as a non-root user.
+                                If true, the Kubelet will validate the image at runtime to ensure that it
+                                does not run as UID 0 (root) and fail to start the container if it does.
+                                If unset or false, no such validation will be performed.
+                                May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: |-
+                                The UID to run the entrypoint of the container process.
+                                Defaults to user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: |-
+                                The SELinux context to be applied to the container.
+                                If unspecified, the container runtime will allocate a random SELinux context for each
+                                container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: |-
+                                The seccomp options to use by this container. If seccomp options are
+                                provided at both the pod & container level, the container options
+                                override the pod options.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                    Must be set if type is "Localhost". Must NOT be set for any other type.
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied.
+                                    Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used.
+                                    RuntimeDefault - the container runtime default profile should be used.
+                                    Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: |-
+                                The Windows specific settings applied to all containers.
+                                If unspecified, the options from the PodSecurityContext will be used.
+                                If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: |-
+                                    GMSACredentialSpec is where the GMSA admission webhook
+                                    (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                    GMSA credential spec named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: |-
+                                    HostProcess determines if a container should be run as a 'Host Process' container.
+                                    All of a Pod's containers must have the same effective HostProcess value
+                                    (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                    In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: |-
+                                    The UserName in Windows to run the entrypoint of the container process.
+                                    Defaults to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: |-
+                            StartupProbe indicates that the Pod has successfully initialized.
+                            If specified, no other probes are executed until this completes successfully.
+                            If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                            This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                            when it might take a long time to load data or warm a cache, than during steady-state operation.
+                            This cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in
+                                the container.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            failureThreshold:
+                              description: |-
+                                Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  default: ""
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest
+                                    (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: |-
+                                Number of seconds after the container has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: |-
+                                How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: |-
+                                Minimum consecutive successes for the probe to be considered successful after having failed.
+                                Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP
+                                port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                value overrides the value provided by the pod spec.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: |-
+                                Number of seconds after which the probe times out.
+                                Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: |-
+                            Whether this container should allocate a buffer for stdin in the container runtime. If this
+                            is not set, reads from stdin in the container will always result in EOF.
+                            Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: |-
+                            Whether the container runtime should close the stdin channel after it has been opened by
+                            a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                            sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                            first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                            at which time stdin is closed and remains closed until the container is restarted. If this
+                            flag is false, a container processes that reads from stdin will never receive an EOF.
+                            Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: |-
+                            Optional: Path at which the file to which the container's termination message
+                            will be written is mounted into the container's filesystem.
+                            Message written is intended to be brief final status, such as an assertion failure message.
+                            Will be truncated by the node if greater than 4096 bytes. The total message length across
+                            all containers will be limited to 12kb.
+                            Defaults to /dev/termination-log.
+                            Cannot be updated.
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of
+                            terminationMessagePath to populate the container status message on both success and failure.
+                            FallbackToLogsOnError will use the last chunk of container log output if the termination
+                            message file is empty and the container exited with an error.
+                            The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                            Defaults to File.
+                            Cannot be updated.
+                          type: string
+                        tty:
+                          description: |-
+                            Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                            Default is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: |-
+                            Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: |-
+                                  Path within the container at which the volume should be mounted.  Must
+                                  not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: |-
+                                  mountPropagation determines how mounts are propagated from the host
+                                  to container and the other way around.
+                                  When not set, MountPropagationNone is used.
+                                  This field is beta in 1.10.
+                                  When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                  (which defaults to None).
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  Mounted read-only if true, read-write otherwise (false or unspecified).
+                                  Defaults to false.
+                                type: boolean
+                              recursiveReadOnly:
+                                description: |-
+                                  RecursiveReadOnly specifies whether read-only mounts should be handled
+                                  recursively.
+
+                                  If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                  If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                  recursively read-only.  If this field is set to IfPossible, the mount is made
+                                  recursively read-only, if it is supported by the container runtime.  If this
+                                  field is set to Enabled, the mount is made recursively read-only if it is
+                                  supported by the container runtime, otherwise the pod will not be started and
+                                  an error will be generated to indicate the reason.
+
+                                  If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                  None (or be unspecified, which defaults to None).
+
+                                  If this field is not specified, it is treated as an equivalent of Disabled.
+                                type: string
+                              subPath:
+                                description: |-
+                                  Path within the volume from which the container's volume should be mounted.
+                                  Defaults to "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: |-
+                                  Expanded path within the volume from which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root).
+                                  SubPathExpr and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: |-
+                            Container's working directory.
+                            If not specified, the container runtime's default will be used, which
+                            might be configured in the container image.
+                            Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  persistUserHome:
+                    description: |-
+                      PersistUserHome defines configuration options for persisting the `/home/user/`
+                      directory in workspaces.
+                    properties:
+                      disableInitContainer:
+                        description: |-
+                          Determines whether the init container that initializes the persistent home directory should be disabled.
+                          When the `/home/user` directory is persisted, the init container is used to initialize the directory before
+                          the workspace starts. If set to true, the init container will not be created.
+                          This field is not used if the `workspace.persistUserHome.enabled` field is set to false.
+                          Enabled by default.
+                        type: boolean
+                      enabled:
+                        description: |-
+                          Determines whether the `/home/user/` directory in workspaces should persist between
+                          workspace shutdown and startup.
+                          Must be used with the 'per-user'/'common' or 'per-workspace' storage class in order to take effect.
+                          Disabled by default.
+                        type: boolean
+                    type: object
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: PodAnnotations defines the metadata.annotations for
+                      DevWorkspace pods created by the DevWorkspace Operator.
+                    type: object
+                  podSecurityContext:
+                    description: |-
+                      PodSecurityContext overrides the default PodSecurityContext used for all workspace-related
+                      pods created by the DevWorkspace Operator. If set, defined values are merged into the default
+                      configuration
+                    properties:
+                      appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile loaded on the node that should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must match the loaded name of the profile.
+                              Must be set if and only if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of AppArmor profile will be applied.
+                              Valid options are:
+                                Localhost - a profile pre-loaded on the node.
+                                RuntimeDefault - the container runtime's default profile.
+                                Unconfined - no AppArmor enforcement.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod.
+                          Some volume types allow the Kubelet to change the ownership of that volume
+                          to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup
+                          2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being exposed inside Pod. This field will only apply to
+                          volume types which support fsGroup based ownership(and permissions).
+                          It will have no effect on ephemeral volume types such as: secret, configmaps
+                          and emptydir.
+                          Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxChangePolicy:
+                        description: |-
+                          seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                          It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                          Valid values are "MountOption" and "Recursive".
+
+                          "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                          This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                          "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                          This requires all Pods that share the same volume to use the same SELinux label.
+                          It is not possible to share the same volume among privileged and unprivileged Pods.
+                          Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                          whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                          CSIDriver instance. Other volumes are always re-labelled recursively.
+                          "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                          If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                          If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                          and "Recursive" for all other volumes.
+
+                          This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                          All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in SecurityContext.  If set in
+                          both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: |-
+                          A list of groups applied to the first process run in each container, in
+                          addition to the container's primary GID and fsGroup (if specified).  If
+                          the SupplementalGroupsPolicy feature is enabled, the
+                          supplementalGroupsPolicy field determines whether these are in addition
+                          to or instead of any group memberships defined in the container image.
+                          If unspecified, no additional groups are added, though group memberships
+                          defined in the container image may still be used, depending on the
+                          supplementalGroupsPolicy field.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      supplementalGroupsPolicy:
+                        description: |-
+                          Defines how supplemental groups of the first container processes are calculated.
+                          Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                          (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                          and the container runtime must implement support for this feature.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      sysctls:
+                        description: |-
+                          Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                          sysctls (by the container runtime) might fail to launch.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  postStartTimeout:
+                    description: |-
+                      PostStartTimeout defines the maximum duration the PostStart hook can run
+                      before it is automatically failed. This timeout is used for the postStart lifecycle hook
+                      that is used to run commands in the workspace container. The timeout is specified in seconds.
+                      Duration should be specified in a format parseable by Go's time package, e.g. "20s", "2m".
+                      If not specified or "0", the timeout is disabled.
+                    type: string
+                  progressTimeout:
+                    description: |-
+                      ProgressTimeout determines the maximum duration a DevWorkspace can be in
+                      a "Starting" or "Failing" phase without progressing before it is automatically failed.
+                      Duration should be specified in a format parseable by Go's time package, e.g.
+                      "15m", "20s", "1h30m", etc. If not specified, the default value of "5m" is used.
+                    type: string
+                  projectClone:
+                    description: |-
+                      ProjectCloneConfig defines configuration related to the project clone init container
+                      that is used to clone git projects into the DevWorkspace.
+                    properties:
+                      env:
+                        description: Env allows defining additional environment variables
+                          for the project clone container.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image is the container image to use for cloning
+                          projects
+                        type: string
+                      imagePullPolicy:
+                        description: |-
+                          ImagePullPolicy configures the imagePullPolicy for the project clone container.
+                          If undefined, the general setting .config.workspace.imagePullPolicy is used instead.
+                        type: string
+                      resources:
+                        description: |-
+                          Resources defines the resource (cpu, memory) limits and requests for the project
+                          clone container. To explicitly not specify a limit or request, define the resource
+                          quantity as zero ('0')
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                  pvcName:
+                    description: |-
+                      PVCName defines the name used for the persistent volume claim created
+                      to support workspace storage when the 'common' storage class is used.
+                      If not specified, the default value of `claim-devworkspace` is used.
+                      Note that changing this configuration value after workspaces have been
+                      created will disconnect all existing workspaces from the previously-used
+                      persistent volume claim, and will require manual removal of the old PVCs
+                      in the cluster.
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  restore:
+                    description: |-
+                      RestoreConfig defines configuration related to the workspace restore init container
+                      that is used to restore workspace data from a backup image.
+                    properties:
+                      env:
+                        description: Env allows defining additional environment variables
+                          for the restore container.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      imagePullPolicy:
+                        description: |-
+                          ImagePullPolicy configures the imagePullPolicy for the restore container.
+                          If undefined, the general setting .config.workspace.imagePullPolicy is used instead.
+                        type: string
+                      resources:
+                        description: |-
+                          Resources defines the resource (cpu, memory) limits and requests for the restore
+                          container. To explicitly not specify a limit or request, define the resource
+                          quantity as zero ('0')
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                  runtimeClassName:
+                    description: RuntimeClassName defines the spec.runtimeClassName
+                      for DevWorkspace pods created by the DevWorkspace Operator.
+                    type: string
+                  schedulerName:
+                    description: |-
+                      SchedulerName is the name of the pod scheduler for DevWorkspace pods.
+                      If not specified, the pod scheduler is set to the default scheduler on the cluster.
+                    type: string
+                  serviceAccount:
+                    description: |-
+                      ServiceAccount defines configuration options for the ServiceAccount used for
+                      DevWorkspaces.
+                    properties:
+                      disableCreation:
+                        description: |-
+                          Disable creation of DevWorkspace ServiceAccounts by the DevWorkspace Operator. If set to true, the serviceAccountName
+                          field must also be set. If ServiceAccount creation is disabled, it is assumed that the specified ServiceAccount already
+                          exists in any namespace where a workspace is created. If a suitable ServiceAccount does not exist, starting DevWorkspaces
+                          will fail.
+                        type: boolean
+                      serviceAccountName:
+                        description: |-
+                          ServiceAccountName defines a fixed name to be used for all DevWorkspaces. If set, the DevWorkspace
+                          Operator will not generate a separate ServiceAccount for each DevWorkspace, and will instead create
+                          a ServiceAccount with the specified name in each namespace where DevWorkspaces are created. If specified,
+                          the created ServiceAccount will not be removed when DevWorkspaces are deleted and must be cleaned up manually.
+                        maxLength: 63
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      serviceAccountTokens:
+                        description: List of ServiceAccount tokens that will be mounted
+                          into workspace pods as projected volumes.
+                        items:
+                          properties:
+                            audience:
+                              description: |-
+                                Audience is the intended audience of the token. A recipient of a token
+                                must identify itself with an identifier specified in the audience of the
+                                token, and otherwise should reject the token. The audience defaults to the
+                                identifier of the apiserver.
+                              type: string
+                            expirationSeconds:
+                              default: 3600
+                              description: |-
+                                ExpirationSeconds is the requested duration of validity of the service
+                                account token. As the token approaches expiration, the kubelet volume
+                                plugin will proactively rotate the service account token. The kubelet will
+                                start trying to rotate the token if the token is older than 80 percent of
+                                its time to live or if the token is older than 24 hours. Defaults to 1 hour
+                                and must be at least 10 minutes.
+                              format: int64
+                              minimum: 600
+                              type: integer
+                            mountPath:
+                              description: |-
+                                Path within the workspace container at which the token should be mounted.  Must
+                                not contain ':'.
+                              type: string
+                            name:
+                              description: |-
+                                Identifiable name of the ServiceAccount token.
+                                If multiple ServiceAccount tokens use the same mount path, a generic name will be used
+                                for the projected volume instead.
+                              type: string
+                            path:
+                              description: |-
+                                Path is the path relative to the mount point of the file to project the
+                                token into.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          - path
+                          type: object
+                        type: array
+                    type: object
+                  storageAccessMode:
+                    description: |-
+                      StorageAccessMode are the desired access modes the volume should have. It defaults
+                      to ReadWriteOnce if not specified
+                    items:
+                      type: string
+                    type: array
+                  storageClassName:
+                    description: |-
+                      StorageClassName defines an optional storageClass to use for persistent
+                      volume claims created to support DevWorkspaces
+                    type: string
+                type: object
+            type: object
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          status:
+            description: |-
+              Status represents the current status of the DevWorkspaceOperatorConfig
+              automatically managed by the DevWorkspace Operator.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the OperatorConfiguration's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastBackupTime:
+                description: |-
+                  LastBackupTime is the timestamp of the last successful backup. Nil if
+                  no backup is configured or no backup has yet succeeded.
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/bases/controller.devfile.io_devworkspaceroutings.yaml
+++ b/config/crd/bases/controller.devfile.io_devworkspaceroutings.yaml
@@ -1,0 +1,5292 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: devworkspaceroutings.controller.devfile.io
+spec:
+  group: controller.devfile.io
+  names:
+    kind: DevWorkspaceRouting
+    listKind: DevWorkspaceRoutingList
+    plural: devworkspaceroutings
+    shortNames:
+      - dwr
+    singular: devworkspacerouting
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The owner DevWorkspace's unique id
+          jsonPath: .spec.devworkspaceId
+          name: DevWorkspace ID
+          type: string
+        - description: The current phase
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+        - description: Additional info about DevWorkspaceRouting state
+          jsonPath: .status.message
+          name: Info
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DevWorkspaceRouting is the Schema for the devworkspaceroutings
+            API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DevWorkspaceRoutingSpec defines the desired state of DevWorkspaceRouting
+              properties:
+                devworkspaceId:
+                  description: Id for the DevWorkspace being routed
+                  type: string
+                endpoints:
+                  additionalProperties:
+                    items:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Map of annotations to be added to the Kubernetes
+                            Ingress or OpenShift Route associated with the endpoint.
+                          type: object
+                        attributes:
+                          description: |-
+                            Map of implementation-dependant string-based free-form attributes.
+
+                            Examples of Che-specific attributes:
+
+                            - cookiesAuthEnabled: "true" / "false",
+
+                            - type: "terminal" / "ide" / "ide-dev",
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        exposure:
+                          default: public
+                          description: |-
+                            Describes how the endpoint should be exposed on the network.
+
+                            - `public` means that the endpoint will be exposed on the public network, typically through
+                            a K8S ingress or an OpenShift route.
+
+                            - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD,
+                            typically by K8S services, to be consumed by other elements running
+                            on the same cloud internal network.
+
+                            - `none` means that the endpoint will not be exposed and will only be accessible
+                            inside the main devworkspace POD, on a local address.
+
+                            Default value is `public`
+                          enum:
+                            - public
+                            - internal
+                            - none
+                          type: string
+                        name:
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        path:
+                          description: Path of the endpoint URL
+                          type: string
+                        protocol:
+                          default: http
+                          description: |-
+                            Describes the application and transport protocols of the traffic that will go through this endpoint.
+
+                            - `http`: Endpoint will have `http` traffic, typically on a TCP connection.
+                            It will be automaticaly promoted to `https` when the `secure` field is set to `true`.
+
+                            - `https`: Endpoint will have `https` traffic, typically on a TCP connection.
+
+                            - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection.
+                            It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.
+
+                            - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.
+
+                            - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.
+
+                            - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.
+
+                            Default value is `http`
+                          enum:
+                            - http
+                            - https
+                            - ws
+                            - wss
+                            - tcp
+                            - udp
+                          type: string
+                        secure:
+                          description: |-
+                            Describes whether the endpoint should be secured and protected by some
+                            authentication process. This requires a protocol of `https` or `wss`.
+                          type: boolean
+                        targetPort:
+                          type: integer
+                      required:
+                        - name
+                        - targetPort
+                      type: object
+                    type: array
+                  description: Machines to endpoints map
+                  type: object
+                podSelector:
+                  additionalProperties:
+                    type: string
+                  description: Selector that should be used by created services to
+                    point to the devworkspace Pod
+                  type: object
+                routingClass:
+                  description: 'Class of the routing: this drives which DevWorkspaceRouting
+                    controller will manage this routing'
+                  type: string
+              required:
+                - devworkspaceId
+                - endpoints
+                - podSelector
+              type: object
+            status:
+              description: DevWorkspaceRoutingStatus defines the observed state of
+                DevWorkspaceRouting
+              properties:
+                exposedEndpoints:
+                  additionalProperties:
+                    items:
+                      properties:
+                        attributes:
+                          description: Attributes of the exposed endpoint
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        name:
+                          description: Name of the exposed endpoint
+                          type: string
+                        url:
+                          description: Public URL of the exposed endpoint
+                          type: string
+                      required:
+                        - name
+                        - url
+                      type: object
+                    type: array
+                  description: Machine name to exposed endpoint map
+                  type: object
+                message:
+                  description: Message is a user-readable message explaining the current
+                    phase (e.g. reason for failure)
+                  type: string
+                phase:
+                  description: Routing reconcile phase
+                  type: string
+                podAdditions:
+                  description: Additions to main devworkspace deployment
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations to be applied to devworkspace deployment
+                      type: object
+                    containers:
+                      description: Containers to add to devworkspace deployment
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: |-
+                              Arguments to the entrypoint.
+                              The container image's CMD is used if this is not provided.
+                              Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                              cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                              produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                              of whether the variable exists or not. Cannot be updated.
+                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          command:
+                            description: |-
+                              Entrypoint array. Not executed within a shell.
+                              The container image's ENTRYPOINT is used if this is not provided.
+                              Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                              cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                              produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                              of whether the variable exists or not. Cannot be updated.
+                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          env:
+                            description: |-
+                              List of environment variables to set in the container.
+                              Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable.
+                                    May consist of any printable ASCII characters except '='.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                        - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      description: |-
+                                        FileKeyRef selects a key of the env file.
+                                        Requires the EnvFiles feature gate to be enabled.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key within the env file. An invalid key will prevent the pod from starting.
+                                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                          type: string
+                                        optional:
+                                          default: false
+                                          description: |-
+                                            Specify whether the file or its key must be defined. If the file or key
+                                            does not exist, then the env var is not published.
+                                            If optional is set to true and the specified key does not exist,
+                                            the environment variable will not be set in the Pod's containers.
+
+                                            If optional is set to false and the specified key does not exist,
+                                            an error will be returned during Pod creation.
+                                          type: boolean
+                                        path:
+                                          description: |-
+                                            The path within the volume from which to select the file.
+                                            Must be relative and may not contain the '..' path or start with '..'.
+                                          type: string
+                                        volumeName:
+                                          description: The name of the volume mount
+                                            containing the env file.
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                        - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                                - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: |-
+                              List of sources to populate environment variables in the container.
+                              The keys defined within a source may consist of any printable ASCII characters except '='.
+                              When a key exists in multiple
+                              sources, the value associated with the last source will take precedence.
+                              Values defined by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps or Secrets
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                prefix:
+                                  description: |-
+                                    Optional text to prepend to the name of each environment variable.
+                                    May consist of any printable ASCII characters except '='.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          image:
+                            description: |-
+                              Container image name.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy.
+                              One of Always, Never, IfNotPresent.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                              Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                            type: string
+                          lifecycle:
+                            description: |-
+                              Actions that the management system should take in response to container lifecycle events.
+                              Cannot be updated.
+                            properties:
+                              postStart:
+                                description: |-
+                                  PostStart is called immediately after a container is created. If the handler fails,
+                                  the container is terminated and restarted according to its restart policy.
+                                  Other management of the container blocks until the hook completes.
+                                  More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute
+                                      in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  sleep:
+                                    description: Sleep represents a duration that
+                                      the container should sleep.
+                                    properties:
+                                      seconds:
+                                        description: Seconds is the number of seconds
+                                          to sleep.
+                                        format: int64
+                                        type: integer
+                                    required:
+                                      - seconds
+                                    type: object
+                                  tcpSocket:
+                                    description: |-
+                                      Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                      for backward compatibility. There is no validation of this field and
+                                      lifecycle hooks will fail at runtime when it is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: |-
+                                  PreStop is called immediately before a container is terminated due to an
+                                  API request or management event such as liveness/startup probe failure,
+                                  preemption, resource contention, etc. The handler is not called if the
+                                  container crashes or exits. The Pod's termination grace period countdown begins before the
+                                  PreStop hook is executed. Regardless of the outcome of the handler, the
+                                  container will eventually terminate within the Pod's termination grace
+                                  period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                  or until the termination grace period is reached.
+                                  More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute
+                                      in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  sleep:
+                                    description: Sleep represents a duration that
+                                      the container should sleep.
+                                    properties:
+                                      seconds:
+                                        description: Seconds is the number of seconds
+                                          to sleep.
+                                        format: int64
+                                        type: integer
+                                    required:
+                                      - seconds
+                                    type: object
+                                  tcpSocket:
+                                    description: |-
+                                      Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                      for backward compatibility. There is no validation of this field and
+                                      lifecycle hooks will fail at runtime when it is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                type: object
+                              stopSignal:
+                                description: |-
+                                  StopSignal defines which signal will be sent to a container when it is being stopped.
+                                  If not specified, the default is defined by the container runtime in use.
+                                  StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                type: string
+                            type: object
+                          livenessProbe:
+                            description: |-
+                              Periodic probe of container liveness.
+                              Container will be restarted if the probe fails.
+                              Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              failureThreshold:
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies a GRPC HealthCheckRequest.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    default: ""
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              initialDelaySeconds:
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies a connection to a
+                                  TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: |-
+                              Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: |-
+                              List of ports to expose from the container. Not specifying a port here
+                              DOES NOT prevent that port from being exposed. Any port which is
+                              listening on the default "0.0.0.0" address inside a container will be
+                              accessible from the network.
+                              Modifying this array with strategic merge patch may corrupt the data.
+                              For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: |-
+                                    Number of port to expose on the pod's IP address.
+                                    This must be a valid port number, 0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: |-
+                                    Number of port to expose on the host.
+                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                    If HostNetwork is specified, this must match ContainerPort.
+                                    Most containers do not need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: |-
+                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                    named port in a pod must have a unique name. Name for the port that can be
+                                    referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                    Defaults to "TCP".
+                                  type: string
+                              required:
+                                - containerPort
+                                - protocol
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: |-
+                              Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if the probe fails.
+                              Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              failureThreshold:
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies a GRPC HealthCheckRequest.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    default: ""
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              initialDelaySeconds:
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies a connection to a
+                                  TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                            type: object
+                          resizePolicy:
+                            description: |-
+                              Resources resize policy for the container.
+                              This field cannot be set on ephemeral containers.
+                            items:
+                              description: ContainerResizePolicy represents resource
+                                resize policy for the container.
+                              properties:
+                                resourceName:
+                                  description: |-
+                                    Name of the resource to which this resource resize policy applies.
+                                    Supported values: cpu, memory.
+                                  type: string
+                                restartPolicy:
+                                  description: |-
+                                    Restart policy to apply when specified resource is resized.
+                                    If not specified, it defaults to NotRequired.
+                                  type: string
+                              required:
+                                - resourceName
+                                - restartPolicy
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          resources:
+                            description: |-
+                              Compute Resources required by this container.
+                              Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          restartPolicy:
+                            description: |-
+                              RestartPolicy defines the restart behavior of individual containers in a pod.
+                              This overrides the pod-level restart policy. When this field is not specified,
+                              the restart behavior is defined by the Pod's restart policy and the container type.
+                              Additionally, setting the RestartPolicy as "Always" for the init container will
+                              have the following effect:
+                              this init container will be continually restarted on
+                              exit until all regular containers have terminated. Once all regular
+                              containers have completed, all init containers with restartPolicy "Always"
+                              will be shut down. This lifecycle differs from normal init containers and
+                              is often referred to as a "sidecar" container. Although this init
+                              container still starts in the init container sequence, it does not wait
+                              for the container to complete before proceeding to the next init
+                              container. Instead, the next init container starts immediately after this
+                              init container is started, or after any startupProbe has successfully
+                              completed.
+                            type: string
+                          restartPolicyRules:
+                            description: |-
+                              Represents a list of rules to be checked to determine if the
+                              container should be restarted on exit. The rules are evaluated in
+                              order. Once a rule matches a container exit condition, the remaining
+                              rules are ignored. If no rule matches the container exit condition,
+                              the Container-level restart policy determines the whether the container
+                              is restarted or not. Constraints on the rules:
+                              - At most 20 rules are allowed.
+                              - Rules can have the same action.
+                              - Identical rules are not forbidden in validations.
+                              When rules are specified, container MUST set RestartPolicy explicitly
+                              even it if matches the Pod's RestartPolicy.
+                            items:
+                              description: ContainerRestartRule describes how a container
+                                exit is handled.
+                              properties:
+                                action:
+                                  description: |-
+                                    Specifies the action taken on a container exit if the requirements
+                                    are satisfied. The only possible value is "Restart" to restart the
+                                    container.
+                                  type: string
+                                exitCodes:
+                                  description: Represents the exit codes to check
+                                    on container exits.
+                                  properties:
+                                    operator:
+                                      description: |-
+                                        Represents the relationship between the container exit code(s) and the
+                                        specified values. Possible values are:
+                                        - In: the requirement is satisfied if the container exit code is in the
+                                          set of specified values.
+                                        - NotIn: the requirement is satisfied if the container exit code is
+                                          not in the set of specified values.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        Specifies the set of values to check for container exit codes.
+                                        At most 255 elements are allowed.
+                                      items:
+                                        format: int32
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  required:
+                                    - operator
+                                  type: object
+                              required:
+                                - action
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          securityContext:
+                            description: |-
+                              SecurityContext defines the security options the container should be run with.
+                              If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: |-
+                                  AllowPrivilegeEscalation controls whether a process can gain more
+                                  privileges than its parent process. This bool directly controls if
+                                  the no_new_privs flag will be set on the container process.
+                                  AllowPrivilegeEscalation is true always when the container is:
+                                  1) run as Privileged
+                                  2) has CAP_SYS_ADMIN
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              appArmorProfile:
+                                description: |-
+                                  appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                  overrides the pod's appArmorProfile.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile loaded on the node that should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must match the loaded name of the profile.
+                                      Must be set if and only if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of AppArmor profile will be applied.
+                                      Valid options are:
+                                        Localhost - a profile pre-loaded on the node.
+                                        RuntimeDefault - the container runtime's default profile.
+                                        Unconfined - no AppArmor enforcement.
+                                    type: string
+                                required:
+                                  - type
+                                type: object
+                              capabilities:
+                                description: |-
+                                  The capabilities to add/drop when running containers.
+                                  Defaults to the default set of capabilities granted by the container runtime.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              privileged:
+                                description: |-
+                                  Run container in privileged mode.
+                                  Processes in privileged containers are essentially equivalent to root on the host.
+                                  Defaults to false.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: |-
+                                  procMount denotes the type of proc mount to use for the containers.
+                                  The default value is Default which uses the container runtime defaults for
+                                  readonly paths and masked paths.
+                                  This requires the ProcMountType feature flag to be enabled.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: |-
+                                  Whether this container has a read-only root filesystem.
+                                  Default is false.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: |-
+                                  The GID to run the entrypoint of the container process.
+                                  Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: |-
+                                  Indicates that the container must run as a non-root user.
+                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                  If unset or false, no such validation will be performed.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: |-
+                                  The UID to run the entrypoint of the container process.
+                                  Defaults to user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: |-
+                                  The SELinux context to be applied to the container.
+                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: |-
+                                  The seccomp options to use by this container. If seccomp options are
+                                  provided at both the pod & container level, the container options
+                                  override the pod options.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied.
+                                      Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used.
+                                      RuntimeDefault - the container runtime default profile should be used.
+                                      Unconfined - no profile should be applied.
+                                    type: string
+                                required:
+                                  - type
+                                type: object
+                              windowsOptions:
+                                description: |-
+                                  The Windows specific settings applied to all containers.
+                                  If unspecified, the options from the PodSecurityContext will be used.
+                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: |-
+                                      GMSACredentialSpec is where the GMSA admission webhook
+                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                      GMSA credential spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: |-
+                                      HostProcess determines if a container should be run as a 'Host Process' container.
+                                      All of a Pod's containers must have the same effective HostProcess value
+                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: |-
+                                      The UserName in Windows to run the entrypoint of the container process.
+                                      Defaults to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: |-
+                              StartupProbe indicates that the Pod has successfully initialized.
+                              If specified, no other probes are executed until this completes successfully.
+                              If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                              This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                              when it might take a long time to load data or warm a cache, than during steady-state operation.
+                              This cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              failureThreshold:
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies a GRPC HealthCheckRequest.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    default: ""
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              initialDelaySeconds:
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies a connection to a
+                                  TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: |-
+                              Whether this container should allocate a buffer for stdin in the container runtime. If this
+                              is not set, reads from stdin in the container will always result in EOF.
+                              Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: |-
+                              Whether the container runtime should close the stdin channel after it has been opened by
+                              a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                              sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                              first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                              at which time stdin is closed and remains closed until the container is restarted. If this
+                              flag is false, a container processes that reads from stdin will never receive an EOF.
+                              Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: |-
+                              Optional: Path at which the file to which the container's termination message
+                              will be written is mounted into the container's filesystem.
+                              Message written is intended to be brief final status, such as an assertion failure message.
+                              Will be truncated by the node if greater than 4096 bytes. The total message length across
+                              all containers will be limited to 12kb.
+                              Defaults to /dev/termination-log.
+                              Cannot be updated.
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of
+                              terminationMessagePath to populate the container status message on both success and failure.
+                              FallbackToLogsOnError will use the last chunk of container log output if the termination
+                              message file is empty and the container exited with an error.
+                              The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                              Defaults to File.
+                              Cannot be updated.
+                            type: string
+                          tty:
+                            description: |-
+                              Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                              Default is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                                - devicePath
+                                - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: |-
+                              Pod volumes to mount into the container's filesystem.
+                              Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
+                                    When not set, MountPropagationNone is used.
+                                    This field is beta in 1.10.
+                                    When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                    (which defaults to None).
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
+                                  type: boolean
+                                recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
+
+                                    If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                    If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                    recursively read-only.  If this field is set to IfPossible, the mount is made
+                                    recursively read-only, if it is supported by the container runtime.  If this
+                                    field is set to Enabled, the mount is made recursively read-only if it is
+                                    supported by the container runtime, otherwise the pod will not be started and
+                                    an error will be generated to indicate the reason.
+
+                                    If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                    None (or be unspecified, which defaults to None).
+
+                                    If this field is not specified, it is treated as an equivalent of Disabled.
+                                  type: string
+                                subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: |-
+                                    Expanded path within the volume from which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                    Defaults to "" (volume's root).
+                                    SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                                - mountPath
+                                - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: |-
+                              Container's working directory.
+                              If not specified, the container runtime's default will be used, which
+                              might be configured in the container image.
+                              Cannot be updated.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    initContainers:
+                      description: Init containers to add to devworkspace deployment
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: |-
+                              Arguments to the entrypoint.
+                              The container image's CMD is used if this is not provided.
+                              Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                              cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                              produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                              of whether the variable exists or not. Cannot be updated.
+                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          command:
+                            description: |-
+                              Entrypoint array. Not executed within a shell.
+                              The container image's ENTRYPOINT is used if this is not provided.
+                              Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                              cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                              produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                              of whether the variable exists or not. Cannot be updated.
+                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          env:
+                            description: |-
+                              List of environment variables to set in the container.
+                              Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable.
+                                    May consist of any printable ASCII characters except '='.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                        - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      description: |-
+                                        FileKeyRef selects a key of the env file.
+                                        Requires the EnvFiles feature gate to be enabled.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key within the env file. An invalid key will prevent the pod from starting.
+                                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                          type: string
+                                        optional:
+                                          default: false
+                                          description: |-
+                                            Specify whether the file or its key must be defined. If the file or key
+                                            does not exist, then the env var is not published.
+                                            If optional is set to true and the specified key does not exist,
+                                            the environment variable will not be set in the Pod's containers.
+
+                                            If optional is set to false and the specified key does not exist,
+                                            an error will be returned during Pod creation.
+                                          type: boolean
+                                        path:
+                                          description: |-
+                                            The path within the volume from which to select the file.
+                                            Must be relative and may not contain the '..' path or start with '..'.
+                                          type: string
+                                        volumeName:
+                                          description: The name of the volume mount
+                                            containing the env file.
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                        - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                                - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: |-
+                              List of sources to populate environment variables in the container.
+                              The keys defined within a source may consist of any printable ASCII characters except '='.
+                              When a key exists in multiple
+                              sources, the value associated with the last source will take precedence.
+                              Values defined by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps or Secrets
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                prefix:
+                                  description: |-
+                                    Optional text to prepend to the name of each environment variable.
+                                    May consist of any printable ASCII characters except '='.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          image:
+                            description: |-
+                              Container image name.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy.
+                              One of Always, Never, IfNotPresent.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                              Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                            type: string
+                          lifecycle:
+                            description: |-
+                              Actions that the management system should take in response to container lifecycle events.
+                              Cannot be updated.
+                            properties:
+                              postStart:
+                                description: |-
+                                  PostStart is called immediately after a container is created. If the handler fails,
+                                  the container is terminated and restarted according to its restart policy.
+                                  Other management of the container blocks until the hook completes.
+                                  More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute
+                                      in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  sleep:
+                                    description: Sleep represents a duration that
+                                      the container should sleep.
+                                    properties:
+                                      seconds:
+                                        description: Seconds is the number of seconds
+                                          to sleep.
+                                        format: int64
+                                        type: integer
+                                    required:
+                                      - seconds
+                                    type: object
+                                  tcpSocket:
+                                    description: |-
+                                      Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                      for backward compatibility. There is no validation of this field and
+                                      lifecycle hooks will fail at runtime when it is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: |-
+                                  PreStop is called immediately before a container is terminated due to an
+                                  API request or management event such as liveness/startup probe failure,
+                                  preemption, resource contention, etc. The handler is not called if the
+                                  container crashes or exits. The Pod's termination grace period countdown begins before the
+                                  PreStop hook is executed. Regardless of the outcome of the handler, the
+                                  container will eventually terminate within the Pod's termination grace
+                                  period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                  or until the termination grace period is reached.
+                                  More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute
+                                      in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  sleep:
+                                    description: Sleep represents a duration that
+                                      the container should sleep.
+                                    properties:
+                                      seconds:
+                                        description: Seconds is the number of seconds
+                                          to sleep.
+                                        format: int64
+                                        type: integer
+                                    required:
+                                      - seconds
+                                    type: object
+                                  tcpSocket:
+                                    description: |-
+                                      Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                      for backward compatibility. There is no validation of this field and
+                                      lifecycle hooks will fail at runtime when it is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                type: object
+                              stopSignal:
+                                description: |-
+                                  StopSignal defines which signal will be sent to a container when it is being stopped.
+                                  If not specified, the default is defined by the container runtime in use.
+                                  StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                type: string
+                            type: object
+                          livenessProbe:
+                            description: |-
+                              Periodic probe of container liveness.
+                              Container will be restarted if the probe fails.
+                              Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              failureThreshold:
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies a GRPC HealthCheckRequest.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    default: ""
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              initialDelaySeconds:
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies a connection to a
+                                  TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: |-
+                              Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: |-
+                              List of ports to expose from the container. Not specifying a port here
+                              DOES NOT prevent that port from being exposed. Any port which is
+                              listening on the default "0.0.0.0" address inside a container will be
+                              accessible from the network.
+                              Modifying this array with strategic merge patch may corrupt the data.
+                              For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: |-
+                                    Number of port to expose on the pod's IP address.
+                                    This must be a valid port number, 0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: |-
+                                    Number of port to expose on the host.
+                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                    If HostNetwork is specified, this must match ContainerPort.
+                                    Most containers do not need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: |-
+                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                    named port in a pod must have a unique name. Name for the port that can be
+                                    referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                    Defaults to "TCP".
+                                  type: string
+                              required:
+                                - containerPort
+                                - protocol
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: |-
+                              Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if the probe fails.
+                              Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              failureThreshold:
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies a GRPC HealthCheckRequest.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    default: ""
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              initialDelaySeconds:
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies a connection to a
+                                  TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                            type: object
+                          resizePolicy:
+                            description: |-
+                              Resources resize policy for the container.
+                              This field cannot be set on ephemeral containers.
+                            items:
+                              description: ContainerResizePolicy represents resource
+                                resize policy for the container.
+                              properties:
+                                resourceName:
+                                  description: |-
+                                    Name of the resource to which this resource resize policy applies.
+                                    Supported values: cpu, memory.
+                                  type: string
+                                restartPolicy:
+                                  description: |-
+                                    Restart policy to apply when specified resource is resized.
+                                    If not specified, it defaults to NotRequired.
+                                  type: string
+                              required:
+                                - resourceName
+                                - restartPolicy
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          resources:
+                            description: |-
+                              Compute Resources required by this container.
+                              Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          restartPolicy:
+                            description: |-
+                              RestartPolicy defines the restart behavior of individual containers in a pod.
+                              This overrides the pod-level restart policy. When this field is not specified,
+                              the restart behavior is defined by the Pod's restart policy and the container type.
+                              Additionally, setting the RestartPolicy as "Always" for the init container will
+                              have the following effect:
+                              this init container will be continually restarted on
+                              exit until all regular containers have terminated. Once all regular
+                              containers have completed, all init containers with restartPolicy "Always"
+                              will be shut down. This lifecycle differs from normal init containers and
+                              is often referred to as a "sidecar" container. Although this init
+                              container still starts in the init container sequence, it does not wait
+                              for the container to complete before proceeding to the next init
+                              container. Instead, the next init container starts immediately after this
+                              init container is started, or after any startupProbe has successfully
+                              completed.
+                            type: string
+                          restartPolicyRules:
+                            description: |-
+                              Represents a list of rules to be checked to determine if the
+                              container should be restarted on exit. The rules are evaluated in
+                              order. Once a rule matches a container exit condition, the remaining
+                              rules are ignored. If no rule matches the container exit condition,
+                              the Container-level restart policy determines the whether the container
+                              is restarted or not. Constraints on the rules:
+                              - At most 20 rules are allowed.
+                              - Rules can have the same action.
+                              - Identical rules are not forbidden in validations.
+                              When rules are specified, container MUST set RestartPolicy explicitly
+                              even it if matches the Pod's RestartPolicy.
+                            items:
+                              description: ContainerRestartRule describes how a container
+                                exit is handled.
+                              properties:
+                                action:
+                                  description: |-
+                                    Specifies the action taken on a container exit if the requirements
+                                    are satisfied. The only possible value is "Restart" to restart the
+                                    container.
+                                  type: string
+                                exitCodes:
+                                  description: Represents the exit codes to check
+                                    on container exits.
+                                  properties:
+                                    operator:
+                                      description: |-
+                                        Represents the relationship between the container exit code(s) and the
+                                        specified values. Possible values are:
+                                        - In: the requirement is satisfied if the container exit code is in the
+                                          set of specified values.
+                                        - NotIn: the requirement is satisfied if the container exit code is
+                                          not in the set of specified values.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        Specifies the set of values to check for container exit codes.
+                                        At most 255 elements are allowed.
+                                      items:
+                                        format: int32
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  required:
+                                    - operator
+                                  type: object
+                              required:
+                                - action
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          securityContext:
+                            description: |-
+                              SecurityContext defines the security options the container should be run with.
+                              If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: |-
+                                  AllowPrivilegeEscalation controls whether a process can gain more
+                                  privileges than its parent process. This bool directly controls if
+                                  the no_new_privs flag will be set on the container process.
+                                  AllowPrivilegeEscalation is true always when the container is:
+                                  1) run as Privileged
+                                  2) has CAP_SYS_ADMIN
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              appArmorProfile:
+                                description: |-
+                                  appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                  overrides the pod's appArmorProfile.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile loaded on the node that should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must match the loaded name of the profile.
+                                      Must be set if and only if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of AppArmor profile will be applied.
+                                      Valid options are:
+                                        Localhost - a profile pre-loaded on the node.
+                                        RuntimeDefault - the container runtime's default profile.
+                                        Unconfined - no AppArmor enforcement.
+                                    type: string
+                                required:
+                                  - type
+                                type: object
+                              capabilities:
+                                description: |-
+                                  The capabilities to add/drop when running containers.
+                                  Defaults to the default set of capabilities granted by the container runtime.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              privileged:
+                                description: |-
+                                  Run container in privileged mode.
+                                  Processes in privileged containers are essentially equivalent to root on the host.
+                                  Defaults to false.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: |-
+                                  procMount denotes the type of proc mount to use for the containers.
+                                  The default value is Default which uses the container runtime defaults for
+                                  readonly paths and masked paths.
+                                  This requires the ProcMountType feature flag to be enabled.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: |-
+                                  Whether this container has a read-only root filesystem.
+                                  Default is false.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: |-
+                                  The GID to run the entrypoint of the container process.
+                                  Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: |-
+                                  Indicates that the container must run as a non-root user.
+                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                  If unset or false, no such validation will be performed.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: |-
+                                  The UID to run the entrypoint of the container process.
+                                  Defaults to user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: |-
+                                  The SELinux context to be applied to the container.
+                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: |-
+                                  The seccomp options to use by this container. If seccomp options are
+                                  provided at both the pod & container level, the container options
+                                  override the pod options.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied.
+                                      Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used.
+                                      RuntimeDefault - the container runtime default profile should be used.
+                                      Unconfined - no profile should be applied.
+                                    type: string
+                                required:
+                                  - type
+                                type: object
+                              windowsOptions:
+                                description: |-
+                                  The Windows specific settings applied to all containers.
+                                  If unspecified, the options from the PodSecurityContext will be used.
+                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: |-
+                                      GMSACredentialSpec is where the GMSA admission webhook
+                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                      GMSA credential spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: |-
+                                      HostProcess determines if a container should be run as a 'Host Process' container.
+                                      All of a Pod's containers must have the same effective HostProcess value
+                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: |-
+                                      The UserName in Windows to run the entrypoint of the container process.
+                                      Defaults to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: |-
+                              StartupProbe indicates that the Pod has successfully initialized.
+                              If specified, no other probes are executed until this completes successfully.
+                              If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                              This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                              when it might take a long time to load data or warm a cache, than during steady-state operation.
+                              This cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              failureThreshold:
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies a GRPC HealthCheckRequest.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    default: ""
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              initialDelaySeconds:
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies a connection to a
+                                  TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: |-
+                              Whether this container should allocate a buffer for stdin in the container runtime. If this
+                              is not set, reads from stdin in the container will always result in EOF.
+                              Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: |-
+                              Whether the container runtime should close the stdin channel after it has been opened by
+                              a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                              sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                              first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                              at which time stdin is closed and remains closed until the container is restarted. If this
+                              flag is false, a container processes that reads from stdin will never receive an EOF.
+                              Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: |-
+                              Optional: Path at which the file to which the container's termination message
+                              will be written is mounted into the container's filesystem.
+                              Message written is intended to be brief final status, such as an assertion failure message.
+                              Will be truncated by the node if greater than 4096 bytes. The total message length across
+                              all containers will be limited to 12kb.
+                              Defaults to /dev/termination-log.
+                              Cannot be updated.
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of
+                              terminationMessagePath to populate the container status message on both success and failure.
+                              FallbackToLogsOnError will use the last chunk of container log output if the termination
+                              message file is empty and the container exited with an error.
+                              The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                              Defaults to File.
+                              Cannot be updated.
+                            type: string
+                          tty:
+                            description: |-
+                              Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                              Default is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                                - devicePath
+                                - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: |-
+                              Pod volumes to mount into the container's filesystem.
+                              Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
+                                    When not set, MountPropagationNone is used.
+                                    This field is beta in 1.10.
+                                    When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                    (which defaults to None).
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
+                                  type: boolean
+                                recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
+
+                                    If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                    If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                    recursively read-only.  If this field is set to IfPossible, the mount is made
+                                    recursively read-only, if it is supported by the container runtime.  If this
+                                    field is set to Enabled, the mount is made recursively read-only if it is
+                                    supported by the container runtime, otherwise the pod will not be started and
+                                    an error will be generated to indicate the reason.
+
+                                    If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                    None (or be unspecified, which defaults to None).
+
+                                    If this field is not specified, it is treated as an equivalent of Disabled.
+                                  type: string
+                                subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: |-
+                                    Expanded path within the volume from which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                    Defaults to "" (volume's root).
+                                    SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                                - mountPath
+                                - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: |-
+                              Container's working directory.
+                              If not specified, the container runtime's default will be used, which
+                              might be configured in the container image.
+                              Cannot be updated.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels to be applied to devworkspace deployment
+                      type: object
+                    pullSecrets:
+                      description: ImagePullSecrets to add to devworkspace deployment
+                      items:
+                        description: |-
+                          LocalObjectReference contains enough information to let you locate the
+                          referenced object inside the same namespace.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    serviceAccountAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations for the devworkspace service account,
+                        it might be used for e.g. OpenShift oauth with SA as auth
+                        client
+                      type: object
+                    volumeMounts:
+                      description: VolumeMounts to add to all containers in a devworkspace
+                        deployment
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        properties:
+                          mountPath:
+                            description: |-
+                              Path within the container at which the volume should be mounted.  Must
+                              not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: |-
+                              mountPropagation determines how mounts are propagated from the host
+                              to container and the other way around.
+                              When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                              When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                              (which defaults to None).
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: |-
+                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                              Defaults to false.
+                            type: boolean
+                          recursiveReadOnly:
+                            description: |-
+                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                              recursively.
+
+                              If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                              If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                              recursively read-only.  If this field is set to IfPossible, the mount is made
+                              recursively read-only, if it is supported by the container runtime.  If this
+                              field is set to Enabled, the mount is made recursively read-only if it is
+                              supported by the container runtime, otherwise the pod will not be started and
+                              an error will be generated to indicate the reason.
+
+                              If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                              None (or be unspecified, which defaults to None).
+
+                              If this field is not specified, it is treated as an equivalent of Disabled.
+                            type: string
+                          subPath:
+                            description: |-
+                              Path within the volume from which the container's volume should be mounted.
+                              Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: |-
+                              Expanded path within the volume from which the container's volume should be mounted.
+                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                              Defaults to "" (volume's root).
+                              SubPathExpr and SubPath are mutually exclusive.
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
+                    volumes:
+                      description: Volumes to add to devworkspace deployment
+                      items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod.
+                        properties:
+                          awsElasticBlockStore:
+                            description: |-
+                              awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                              kubelet's host machine and then exposed to the pod.
+                              Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                              awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type of the volume that you want to mount.
+                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                type: string
+                              partition:
+                                description: |-
+                                  partition is the partition in the volume that you want to mount.
+                                  If omitted, the default is to mount by volume name.
+                                  Examples: For volume /dev/sda1, you specify the partition as "1".
+                                  Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: |-
+                                  readOnly value true will force the readOnly setting in VolumeMounts.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                type: boolean
+                              volumeID:
+                                description: |-
+                                  volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                type: string
+                            required:
+                              - volumeID
+                            type: object
+                          azureDisk:
+                            description: |-
+                              azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                              are redirected to the disk.csi.azure.com CSI driver.
+                            properties:
+                              cachingMode:
+                                description: 'cachingMode is the Host Caching mode:
+                                  None, Read Only, Read Write.'
+                                type: string
+                              diskName:
+                                description: diskName is the Name of the data disk
+                                  in the blob storage
+                                type: string
+                              diskURI:
+                                description: diskURI is the URI of data disk in the
+                                  blob storage
+                                type: string
+                              fsType:
+                                default: ext4
+                                description: |-
+                                  fsType is Filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              kind:
+                                description: 'kind expected values are Shared: multiple
+                                  blob disks per storage account  Dedicated: single
+                                  blob disk per storage account  Managed: azure managed
+                                  data disk (only in managed availability set). defaults
+                                  to shared'
+                                type: string
+                              readOnly:
+                                default: false
+                                description: |-
+                                  readOnly Defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                            required:
+                              - diskName
+                              - diskURI
+                            type: object
+                          azureFile:
+                            description: |-
+                              azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                              are redirected to the file.csi.azure.com CSI driver.
+                            properties:
+                              readOnly:
+                                description: |-
+                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretName:
+                                description: secretName is the  name of secret that
+                                  contains Azure Storage Account Name and Key
+                                type: string
+                              shareName:
+                                description: shareName is the azure share Name
+                                type: string
+                            required:
+                              - secretName
+                              - shareName
+                            type: object
+                          cephfs:
+                            description: |-
+                              cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                              Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                            properties:
+                              monitors:
+                                description: |-
+                                  monitors is Required: Monitors is a collection of Ceph monitors
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              path:
+                                description: 'path is Optional: Used as the mounted
+                                  root, rather than the full Ceph tree, default is
+                                  /'
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                type: boolean
+                              secretFile:
+                                description: |-
+                                  secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                type: string
+                              secretRef:
+                                description: |-
+                                  secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              user:
+                                description: |-
+                                  user is optional: User is the rados user name, default is admin
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                type: string
+                            required:
+                              - monitors
+                            type: object
+                          cinder:
+                            description: |-
+                              cinder represents a cinder volume attached and mounted on kubelets host machine.
+                              Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                              are redirected to the cinder.csi.openstack.org CSI driver.
+                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef is optional: points to a secret object containing parameters used to connect
+                                  to OpenStack.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              volumeID:
+                                description: |-
+                                  volumeID used to identify the volume in cinder.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                type: string
+                            required:
+                              - volumeID
+                            type: object
+                          configMap:
+                            description: configMap represents a configMap that should
+                              populate this volume
+                            properties:
+                              defaultMode:
+                                description: |-
+                                  defaultMode is optional: mode bits used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  Defaults to 0644.
+                                  Directories within the path are not affected by this setting.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              items:
+                                description: |-
+                                  items if unspecified, each key-value pair in the Data field of the referenced
+                                  ConfigMap will be projected into the volume as a file whose name is the
+                                  key and content is the value. If specified, the listed keys will be
+                                  projected into the specified paths, and unlisted keys will not be
+                                  present. If a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          csi:
+                            description: csi (Container Storage Interface) represents
+                              ephemeral storage that is handled by certain external
+                              CSI drivers.
+                            properties:
+                              driver:
+                                description: |-
+                                  driver is the name of the CSI driver that handles this volume.
+                                  Consult with your admin for the correct name as registered in the cluster.
+                                type: string
+                              fsType:
+                                description: |-
+                                  fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                  If not provided, the empty value is passed to the associated CSI driver
+                                  which will determine the default filesystem to apply.
+                                type: string
+                              nodePublishSecretRef:
+                                description: |-
+                                  nodePublishSecretRef is a reference to the secret object containing
+                                  sensitive information to pass to the CSI driver to complete the CSI
+                                  NodePublishVolume and NodeUnpublishVolume calls.
+                                  This field is optional, and  may be empty if no secret is required. If the
+                                  secret object contains more than one secret, all secret references are passed.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              readOnly:
+                                description: |-
+                                  readOnly specifies a read-only configuration for the volume.
+                                  Defaults to false (read/write).
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  volumeAttributes stores driver-specific properties that are passed to the CSI
+                                  driver. Consult your driver's documentation for supported values.
+                                type: object
+                            required:
+                              - driver
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI represents downward API about
+                              the pod that should populate this volume
+                            properties:
+                              defaultMode:
+                                description: |-
+                                  Optional: mode bits to use on created files by default. Must be a
+                                  Optional: mode bits used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  Defaults to 0644.
+                                  Directories within the path are not affected by this setting.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              items:
+                                description: Items is a list of downward API volume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name, namespace
+                                        and uid are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                        - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    mode:
+                                      description: |-
+                                        Optional: mode bits used to set permissions on this file, must be an octal value
+                                        between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                        - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          emptyDir:
+                            description: |-
+                              emptyDir represents a temporary directory that shares a pod's lifetime.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                            properties:
+                              medium:
+                                description: |-
+                                  medium represents what type of storage medium should back this directory.
+                                  The default is "" which means to use the node's default medium.
+                                  Must be an empty string (default) or Memory.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                  The size limit is also applicable for memory medium.
+                                  The maximum usage on memory medium EmptyDir would be the minimum value between
+                                  the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                  The default is nil which means that the limit is undefined.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            description: |-
+                              ephemeral represents a volume that is handled by a cluster storage driver.
+                              The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                              and deleted when the pod is removed.
+
+                              Use this if:
+                              a) the volume is only needed while the pod runs,
+                              b) features of normal volumes like restoring from snapshot or capacity
+                                 tracking are needed,
+                              c) the storage driver is specified through a storage class, and
+                              d) the storage driver supports dynamic volume provisioning through
+                                 a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                 information on the connection between this volume type
+                                 and PersistentVolumeClaim).
+
+                              Use PersistentVolumeClaim or one of the vendor-specific
+                              APIs for volumes that persist for longer than the lifecycle
+                              of an individual pod.
+
+                              Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                              be used that way - see the documentation of the driver for
+                              more information.
+
+                              A pod can use both types of ephemeral volumes and
+                              persistent volumes at the same time.
+                            properties:
+                              volumeClaimTemplate:
+                                description: |-
+                                  Will be used to create a stand-alone PVC to provision the volume.
+                                  The pod in which this EphemeralVolumeSource is embedded will be the
+                                  owner of the PVC, i.e. the PVC will be deleted together with the
+                                  pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                  `<volume name>` is the name from the `PodSpec.Volumes` array
+                                  entry. Pod validation will reject the pod if the concatenated name
+                                  is not valid for a PVC (for example, too long).
+
+                                  An existing PVC with that name that is not owned by the pod
+                                  will *not* be used for the pod to avoid using an unrelated
+                                  volume by mistake. Starting the pod is then blocked until
+                                  the unrelated PVC is removed. If such a pre-created PVC is
+                                  meant to be used by the pod, the PVC has to updated with an
+                                  owner reference to the pod once the pod exists. Normally
+                                  this should not be necessary, but it may be useful when
+                                  manually reconstructing a broken cluster.
+
+                                  This field is read-only and no changes will be made by Kubernetes
+                                  to the PVC after it has been created.
+
+                                  Required, must not be nil.
+                                properties:
+                                  metadata:
+                                    description: |-
+                                      May contain labels and annotations that will be copied into the PVC
+                                      when creating it. No other fields are allowed and will be rejected during
+                                      validation.
+                                    type: object
+                                  spec:
+                                    description: |-
+                                      The specification for the PersistentVolumeClaim. The entire content is
+                                      copied unchanged into the PVC that gets created from this
+                                      template. The same fields as in a PersistentVolumeClaim
+                                      are also valid here.
+                                    properties:
+                                      accessModes:
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          Users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over
+                                          volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: |-
+                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                          If specified, the CSI driver will create or update the volume with the attributes defined
+                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
+                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                          exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        type: string
+                                      volumeMode:
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                required:
+                                  - spec
+                                type: object
+                            type: object
+                          fc:
+                            description: fc represents a Fibre Channel resource that
+                              is attached to a kubelet's host machine and then exposed
+                              to the pod.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              lun:
+                                description: 'lun is Optional: FC target lun number'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: |-
+                                  readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              targetWWNs:
+                                description: 'targetWWNs is Optional: FC target worldwide
+                                  names (WWNs)'
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              wwids:
+                                description: |-
+                                  wwids Optional: FC volume world wide identifiers (wwids)
+                                  Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          flexVolume:
+                            description: |-
+                              flexVolume represents a generic volume resource that is
+                              provisioned/attached using an exec based plugin.
+                              Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                            properties:
+                              driver:
+                                description: driver is the name of the driver to use
+                                  for this volume.
+                                type: string
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                description: 'options is Optional: this field holds
+                                  extra command options if any.'
+                                type: object
+                              readOnly:
+                                description: |-
+                                  readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef is Optional: secretRef is reference to the secret object containing
+                                  sensitive information to pass to the plugin scripts. This may be
+                                  empty if no secret object is specified. If the secret object
+                                  contains more than one secret, all secrets are passed to the plugin
+                                  scripts.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                              - driver
+                            type: object
+                          flocker:
+                            description: |-
+                              flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                              Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                            properties:
+                              datasetName:
+                                description: |-
+                                  datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                  should be considered as deprecated
+                                type: string
+                              datasetUUID:
+                                description: datasetUUID is the UUID of the dataset.
+                                  This is unique identifier of a Flocker dataset
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            description: |-
+                              gcePersistentDisk represents a GCE Disk resource that is attached to a
+                              kubelet's host machine and then exposed to the pod.
+                              Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                              gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is filesystem type of the volume that you want to mount.
+                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                type: string
+                              partition:
+                                description: |-
+                                  partition is the partition in the volume that you want to mount.
+                                  If omitted, the default is to mount by volume name.
+                                  Examples: For volume /dev/sda1, you specify the partition as "1".
+                                  Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                format: int32
+                                type: integer
+                              pdName:
+                                description: |-
+                                  pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the ReadOnly setting in VolumeMounts.
+                                  Defaults to false.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                type: boolean
+                            required:
+                              - pdName
+                            type: object
+                          gitRepo:
+                            description: |-
+                              gitRepo represents a git repository at a particular revision.
+                              Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                              EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                              into the Pod's container.
+                            properties:
+                              directory:
+                                description: |-
+                                  directory is the target directory name.
+                                  Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                  git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                  the subdirectory with the given name.
+                                type: string
+                              repository:
+                                description: repository is the URL
+                                type: string
+                              revision:
+                                description: revision is the commit hash for the specified
+                                  revision.
+                                type: string
+                            required:
+                              - repository
+                            type: object
+                          glusterfs:
+                            description: |-
+                              glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                              Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                            properties:
+                              endpoints:
+                                description: endpoints is the endpoint name that details
+                                  Glusterfs topology.
+                                type: string
+                              path:
+                                description: |-
+                                  path is the Glusterfs volume path.
+                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                  Defaults to false.
+                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                type: boolean
+                            required:
+                              - endpoints
+                              - path
+                            type: object
+                          hostPath:
+                            description: |-
+                              hostPath represents a pre-existing file or directory on the host
+                              machine that is directly exposed to the container. This is generally
+                              used for system agents or other privileged things that are allowed
+                              to see the host machine. Most containers will NOT need this.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                            properties:
+                              path:
+                                description: |-
+                                  path of the directory on the host.
+                                  If the path is a symlink, it will follow the link to the real path.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                type: string
+                              type:
+                                description: |-
+                                  type for HostPath Volume
+                                  Defaults to ""
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                type: string
+                            required:
+                              - path
+                            type: object
+                          image:
+                            description: |-
+                              image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                              The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                              - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                              The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                              A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                              The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                              The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                              The volume will be mounted read-only (ro) and non-executable files (noexec).
+                              Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                              The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          iscsi:
+                            description: |-
+                              iscsi represents an ISCSI Disk resource that is attached to a
+                              kubelet's host machine and then exposed to the pod.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                            properties:
+                              chapAuthDiscovery:
+                                description: chapAuthDiscovery defines whether support
+                                  iSCSI Discovery CHAP authentication
+                                type: boolean
+                              chapAuthSession:
+                                description: chapAuthSession defines whether support
+                                  iSCSI Session CHAP authentication
+                                type: boolean
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type of the volume that you want to mount.
+                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                type: string
+                              initiatorName:
+                                description: |-
+                                  initiatorName is the custom iSCSI Initiator Name.
+                                  If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                  <target portal>:<volume name> will be created for the connection.
+                                type: string
+                              iqn:
+                                description: iqn is the target iSCSI Qualified Name.
+                                type: string
+                              iscsiInterface:
+                                default: default
+                                description: |-
+                                  iscsiInterface is the interface Name that uses an iSCSI transport.
+                                  Defaults to 'default' (tcp).
+                                type: string
+                              lun:
+                                description: lun represents iSCSI Target Lun number.
+                                format: int32
+                                type: integer
+                              portals:
+                                description: |-
+                                  portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                  is other than default (typically TCP ports 860 and 3260).
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the ReadOnly setting in VolumeMounts.
+                                  Defaults to false.
+                                type: boolean
+                              secretRef:
+                                description: secretRef is the CHAP Secret for iSCSI
+                                  target and initiator authentication
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              targetPortal:
+                                description: |-
+                                  targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                  is other than default (typically TCP ports 860 and 3260).
+                                type: string
+                            required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                            type: object
+                          name:
+                            description: |-
+                              name of the volume.
+                              Must be a DNS_LABEL and unique within the pod.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          nfs:
+                            description: |-
+                              nfs represents an NFS mount on the host that shares a pod's lifetime
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                            properties:
+                              path:
+                                description: |-
+                                  path that is exported by the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the NFS export to be mounted with read-only permissions.
+                                  Defaults to false.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                type: boolean
+                              server:
+                                description: |-
+                                  server is the hostname or IP address of the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                type: string
+                            required:
+                              - path
+                              - server
+                            type: object
+                          persistentVolumeClaim:
+                            description: |-
+                              persistentVolumeClaimVolumeSource represents a reference to a
+                              PersistentVolumeClaim in the same namespace.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                            properties:
+                              claimName:
+                                description: |-
+                                  claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly Will force the ReadOnly setting in VolumeMounts.
+                                  Default false.
+                                type: boolean
+                            required:
+                              - claimName
+                            type: object
+                          photonPersistentDisk:
+                            description: |-
+                              photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                              Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              pdID:
+                                description: pdID is the ID that identifies Photon
+                                  Controller persistent disk
+                                type: string
+                            required:
+                              - pdID
+                            type: object
+                          portworxVolume:
+                            description: |-
+                              portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                              Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                              are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                              is on.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fSType represents the filesystem type to mount
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              volumeID:
+                                description: volumeID uniquely identifies a Portworx
+                                  volume
+                                type: string
+                            required:
+                              - volumeID
+                            type: object
+                          projected:
+                            description: projected items for all in one resources
+                              secrets, configmaps, and downward API
+                            properties:
+                              defaultMode:
+                                description: |-
+                                  defaultMode are the mode bits used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  Directories within the path are not affected by this setting.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              sources:
+                                description: |-
+                                  sources is the list of volume projections. Each entry in this list
+                                  handles one source.
+                                items:
+                                  description: |-
+                                    Projection that may be projected along with other supported volume types.
+                                    Exactly one of these fields must be set.
+                                  properties:
+                                    clusterTrustBundle:
+                                      description: |-
+                                        ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                        of ClusterTrustBundle objects in an auto-updating file.
+
+                                        Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                        ClusterTrustBundle objects can either be selected by name, or by the
+                                        combination of signer name and a label selector.
+
+                                        Kubelet performs aggressive normalization of the PEM contents written
+                                        into the pod filesystem.  Esoteric PEM features such as inter-block
+                                        comments and block headers are stripped.  Certificates are deduplicated.
+                                        The ordering of certificates within the file is arbitrary, and Kubelet
+                                        may change the order over time.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            Select all ClusterTrustBundles that match this label selector.  Only has
+                                            effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                            interpreted as "match nothing".  If set but empty, interpreted as "match
+                                            everything".
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        name:
+                                          description: |-
+                                            Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                            with signerName and labelSelector.
+                                          type: string
+                                        optional:
+                                          description: |-
+                                            If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                            aren't available.  If using name, then the named ClusterTrustBundle is
+                                            allowed not to exist.  If using signerName, then the combination of
+                                            signerName and labelSelector is allowed to match zero
+                                            ClusterTrustBundles.
+                                          type: boolean
+                                        path:
+                                          description: Relative path from the volume
+                                            root to write the bundle.
+                                          type: string
+                                        signerName:
+                                          description: |-
+                                            Select all ClusterTrustBundles that match this signer name.
+                                            Mutually-exclusive with name.  The contents of all selected
+                                            ClusterTrustBundles will be unified and deduplicated.
+                                          type: string
+                                      required:
+                                        - path
+                                      type: object
+                                    configMap:
+                                      description: configMap information about the
+                                        configMap data to project
+                                      properties:
+                                        items:
+                                          description: |-
+                                            items if unspecified, each key-value pair in the Data field of the referenced
+                                            ConfigMap will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the ConfigMap,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: |-
+                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: |-
+                                                  path is the relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    downwardAPI:
+                                      description: downwardAPI information about the
+                                        downwardAPI data to project
+                                      properties:
+                                        items:
+                                          description: Items is a list of DownwardAPIVolume
+                                            file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name, namespace and uid
+                                                  are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                  - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                description: |-
+                                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                                  between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                  - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    podCertificate:
+                                      description: |-
+                                        Projects an auto-rotating credential bundle (private key and certificate
+                                        chain) that the pod can use either as a TLS client or server.
+
+                                        Kubelet generates a private key and uses it to send a
+                                        PodCertificateRequest to the named signer.  Once the signer approves the
+                                        request and issues a certificate chain, Kubelet writes the key and
+                                        certificate chain to the pod filesystem.  The pod does not start until
+                                        certificates have been issued for each podCertificate projected volume
+                                        source in its spec.
+
+                                        Kubelet will begin trying to rotate the certificate at the time indicated
+                                        by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                        timestamp.
+
+                                        Kubelet can write a single file, indicated by the credentialBundlePath
+                                        field, or separate files, indicated by the keyPath and
+                                        certificateChainPath fields.
+
+                                        The credential bundle is a single file in PEM format.  The first PEM
+                                        entry is the private key (in PKCS#8 format), and the remaining PEM
+                                        entries are the certificate chain issued by the signer (typically,
+                                        signers will return their certificate chain in leaf-to-root order).
+
+                                        Prefer using the credential bundle format, since your application code
+                                        can read it atomically.  If you use keyPath and certificateChainPath,
+                                        your application must make two separate file reads. If these coincide
+                                        with a certificate rotation, it is possible that the private key and leaf
+                                        certificate you read may not correspond to each other.  Your application
+                                        will need to check for this condition, and re-read until they are
+                                        consistent.
+
+                                        The named signer controls chooses the format of the certificate it
+                                        issues; consult the signer implementation's documentation to learn how to
+                                        use the certificates it issues.
+                                      properties:
+                                        certificateChainPath:
+                                          description: |-
+                                            Write the certificate chain at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        credentialBundlePath:
+                                          description: |-
+                                            Write the credential bundle at this path in the projected volume.
+
+                                            The credential bundle is a single file that contains multiple PEM blocks.
+                                            The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                            key.
+
+                                            The remaining blocks are CERTIFICATE blocks, containing the issued
+                                            certificate chain from the signer (leaf and any intermediates).
+
+                                            Using credentialBundlePath lets your Pod's application code make a single
+                                            atomic read that retrieves a consistent key and certificate chain.  If you
+                                            project them to separate files, your application code will need to
+                                            additionally check that the leaf certificate was issued to the key.
+                                          type: string
+                                        keyPath:
+                                          description: |-
+                                            Write the key at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        keyType:
+                                          description: |-
+                                            The type of keypair Kubelet will generate for the pod.
+
+                                            Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                            "ECDSAP521", and "ED25519".
+                                          type: string
+                                        maxExpirationSeconds:
+                                          description: |-
+                                            maxExpirationSeconds is the maximum lifetime permitted for the
+                                            certificate.
+
+                                            Kubelet copies this value verbatim into the PodCertificateRequests it
+                                            generates for this projection.
+
+                                            If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                            will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                            value is 7862400 (91 days).
+
+                                            The signer implementation is then free to issue a certificate with any
+                                            lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                            seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                            `kubernetes.io` signers will never issue certificates with a lifetime
+                                            longer than 24 hours.
+                                          format: int32
+                                          type: integer
+                                        signerName:
+                                          description: Kubelet's generated CSRs will
+                                            be addressed to this signer.
+                                          type: string
+                                        userAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            userAnnotations allow pod authors to pass additional information to
+                                            the signer implementation.  Kubernetes does not restrict or validate this
+                                            metadata in any way.
+
+                                            These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                            the PodCertificateRequest objects that Kubelet creates.
+
+                                            Entries are subject to the same validation as object metadata annotations,
+                                            with the addition that all keys must be domain-prefixed. No restrictions
+                                            are placed on values, except an overall size limitation on the entire field.
+
+                                            Signers should document the keys and values they support. Signers should
+                                            deny requests that contain keys they do not recognize.
+                                          type: object
+                                      required:
+                                        - keyType
+                                        - signerName
+                                      type: object
+                                    secret:
+                                      description: secret information about the secret
+                                        data to project
+                                      properties:
+                                        items:
+                                          description: |-
+                                            items if unspecified, each key-value pair in the Data field of the referenced
+                                            Secret will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the Secret,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: |-
+                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: |-
+                                                  path is the relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its key must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    serviceAccountToken:
+                                      description: serviceAccountToken is information
+                                        about the serviceAccountToken data to project
+                                      properties:
+                                        audience:
+                                          description: |-
+                                            audience is the intended audience of the token. A recipient of a token
+                                            must identify itself with an identifier specified in the audience of the
+                                            token, and otherwise should reject the token. The audience defaults to the
+                                            identifier of the apiserver.
+                                          type: string
+                                        expirationSeconds:
+                                          description: |-
+                                            expirationSeconds is the requested duration of validity of the service
+                                            account token. As the token approaches expiration, the kubelet volume
+                                            plugin will proactively rotate the service account token. The kubelet will
+                                            start trying to rotate the token if the token is older than 80 percent of
+                                            its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                            and must be at least 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the path relative to the mount point of the file to project the
+                                            token into.
+                                          type: string
+                                      required:
+                                        - path
+                                      type: object
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          quobyte:
+                            description: |-
+                              quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                              Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                            properties:
+                              group:
+                                description: |-
+                                  group to map volume access to
+                                  Default is no group
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                  Defaults to false.
+                                type: boolean
+                              registry:
+                                description: |-
+                                  registry represents a single or multiple Quobyte Registry services
+                                  specified as a string as host:port pair (multiple entries are separated with commas)
+                                  which acts as the central registry for volumes
+                                type: string
+                              tenant:
+                                description: |-
+                                  tenant owning the given Quobyte volume in the Backend
+                                  Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                type: string
+                              user:
+                                description: |-
+                                  user to map volume access to
+                                  Defaults to serivceaccount user
+                                type: string
+                              volume:
+                                description: volume is a string that references an
+                                  already created Quobyte volume by name.
+                                type: string
+                            required:
+                              - registry
+                              - volume
+                            type: object
+                          rbd:
+                            description: |-
+                              rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                              Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type of the volume that you want to mount.
+                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                type: string
+                              image:
+                                description: |-
+                                  image is the rados image name.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: string
+                              keyring:
+                                default: /etc/ceph/keyring
+                                description: |-
+                                  keyring is the path to key ring for RBDUser.
+                                  Default is /etc/ceph/keyring.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: string
+                              monitors:
+                                description: |-
+                                  monitors is a collection of Ceph monitors.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              pool:
+                                default: rbd
+                                description: |-
+                                  pool is the rados pool name.
+                                  Default is rbd.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the ReadOnly setting in VolumeMounts.
+                                  Defaults to false.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef is name of the authentication secret for RBDUser. If provided
+                                  overrides keyring.
+                                  Default is nil.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              user:
+                                default: admin
+                                description: |-
+                                  user is the rados user name.
+                                  Default is admin.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: string
+                            required:
+                              - image
+                              - monitors
+                            type: object
+                          scaleIO:
+                            description: |-
+                              scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                            properties:
+                              fsType:
+                                default: xfs
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs".
+                                  Default is "xfs".
+                                type: string
+                              gateway:
+                                description: gateway is the host address of the ScaleIO
+                                  API Gateway.
+                                type: string
+                              protectionDomain:
+                                description: protectionDomain is the name of the ScaleIO
+                                  Protection Domain for the configured storage.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly Defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef references to the secret for ScaleIO user and other
+                                  sensitive information. If this is not provided, Login operation will fail.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              sslEnabled:
+                                description: sslEnabled Flag enable/disable SSL communication
+                                  with Gateway, default false
+                                type: boolean
+                              storageMode:
+                                default: ThinProvisioned
+                                description: |-
+                                  storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                  Default is ThinProvisioned.
+                                type: string
+                              storagePool:
+                                description: storagePool is the ScaleIO Storage Pool
+                                  associated with the protection domain.
+                                type: string
+                              system:
+                                description: system is the name of the storage system
+                                  as configured in ScaleIO.
+                                type: string
+                              volumeName:
+                                description: |-
+                                  volumeName is the name of a volume already created in the ScaleIO system
+                                  that is associated with this volume source.
+                                type: string
+                            required:
+                              - gateway
+                              - secretRef
+                              - system
+                            type: object
+                          secret:
+                            description: |-
+                              secret represents a secret that should populate this volume.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                            properties:
+                              defaultMode:
+                                description: |-
+                                  defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values
+                                  for mode bits. Defaults to 0644.
+                                  Directories within the path are not affected by this setting.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              items:
+                                description: |-
+                                  items If unspecified, each key-value pair in the Data field of the referenced
+                                  Secret will be projected into the volume as a file whose name is the
+                                  key and content is the value. If specified, the listed keys will be
+                                  projected into the specified paths, and unlisted keys will not be
+                                  present. If a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its keys must be defined
+                                type: boolean
+                              secretName:
+                                description: |-
+                                  secretName is the name of the secret in the pod's namespace to use.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                type: string
+                            type: object
+                          storageos:
+                            description: |-
+                              storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef specifies the secret to use for obtaining the StorageOS API
+                                  credentials.  If not specified, default values will be attempted.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              volumeName:
+                                description: |-
+                                  volumeName is the human-readable name of the StorageOS volume.  Volume
+                                  names are only unique within a namespace.
+                                type: string
+                              volumeNamespace:
+                                description: |-
+                                  volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                  namespace is specified then the Pod's namespace will be used.  This allows the
+                                  Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                  Set VolumeName to any name to override the default behaviour.
+                                  Set to "default" if you are not using namespaces within StorageOS.
+                                  Namespaces that do not pre-exist within StorageOS will be created.
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            description: |-
+                              vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                              Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                              are redirected to the csi.vsphere.vmware.com CSI driver.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              storagePolicyID:
+                                description: storagePolicyID is the storage Policy
+                                  Based Management (SPBM) profile ID associated with
+                                  the StoragePolicyName.
+                                type: string
+                              storagePolicyName:
+                                description: storagePolicyName is the storage Policy
+                                  Based Management (SPBM) profile name.
+                                type: string
+                              volumePath:
+                                description: volumePath is the path that identifies
+                                  vSphere volume vmdk
+                                type: string
+                            required:
+                              - volumePath
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/controllers/controller/devworkspacerouting/suite_test.go
+++ b/controllers/controller/devworkspacerouting/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"testing"
 
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	dwv1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
@@ -121,6 +122,9 @@ var _ = BeforeSuite(func() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:   scheme.Scheme,
 		NewCache: cacheFunc,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // Disable metrics server in tests to avoid port conflicts
+		},
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port: 9443,
 		}),

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -434,7 +434,9 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// Ensure init-persistent-home container has correct fields after merge
 		for i := range merged {
 			if merged[i].Name == constants.HomeInitComponentName {
-				home.EnsureHomeInitContainerFields(&merged[i], home.InferWorkspaceImage(&workspace.Spec.Template), constants.HomeVolumeName)
+				if err := home.EnsureHomeInitContainerFields(&merged[i]); err != nil {
+					return r.failWorkspace(workspace, fmt.Sprintf("Failed to validate init-persistent-home container: %s", err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus), nil
+				}
 			}
 		}
 

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -434,9 +434,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// Ensure init-persistent-home container has correct fields after merge
 		for i := range merged {
 			if merged[i].Name == constants.HomeInitComponentName {
-				if err := home.EnsureHomeInitContainerFields(&merged[i]); err != nil {
-					return r.failWorkspace(workspace, fmt.Sprintf("Failed to configure %s container: %s", constants.HomeInitComponentName, err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus), nil
-				}
+				home.EnsureHomeInitContainerFields(&merged[i], home.InferWorkspaceImage(&workspace.Spec.Template), constants.HomeVolumeName)
 			}
 		}
 

--- a/controllers/workspace/devworkspace_controller_test.go
+++ b/controllers/workspace/devworkspace_controller_test.go
@@ -1809,22 +1809,21 @@ var _ = Describe("DevWorkspace Controller", func() {
 			By("Setting the deployment to have 1 ready replica")
 			markDeploymentReady(common.DeploymentName(workspaceID))
 
-			By("Verifying the default init-persistent-home container is present in the deployment")
-			deploy := &appsv1.Deployment{}
-			deployNN := namespacedName(common.DeploymentName(workspaceID), testNamespace)
-			Eventually(func() error {
-				if err := k8sClient.Get(ctx, deployNN, deploy); err != nil {
-					return fmt.Errorf("failed to get deployment: %w", err)
+			By("Verifying the workspace reaches Running phase without error (backward compat with nil InitContainers)")
+			// Note: test-devworkspace.yaml uses ephemeral storage so NeedsPersistentHomeDirectory
+			// returns false when InitContainers is nil. The backward-compat test verifies
+			// the workspace reconciles without error (reaches Running phase), not that an
+			// init-persistent-home container is added (which requires non-ephemeral storage
+			// or explicit DWOC config for ephemeral storage).
+			workspace := &dw.DevWorkspace{}
+			dwNamespacedName := namespacedName(devWorkspaceName, testNamespace)
+			Eventually(func() (dw.DevWorkspacePhase, error) {
+				if err := k8sClient.Get(ctx, dwNamespacedName, workspace); err != nil {
+					return "", err
 				}
-				for _, c := range deploy.Spec.Template.Spec.InitContainers {
-					if c.Name == constants.HomeInitComponentName {
-						return nil
-					}
-				}
-				return fmt.Errorf("init container %q not found in deployment; init containers: %v",
-					constants.HomeInitComponentName, deploy.Spec.Template.Spec.InitContainers)
-			}, 30*time.Second, 1*time.Second).Should(Succeed(),
-				"default init-persistent-home should be present when no custom init containers are configured")
+				return workspace.Status.Phase, nil
+			}, 30*time.Second, 1*time.Second).Should(Equal(dw.DevWorkspaceStatusRunning),
+				"workspace should reach Running phase when no custom init containers are configured")
 		})
 
 		It("AdditionalInitContainersInjected: additional non-home init containers are injected after init-persistent-home", func() {

--- a/controllers/workspace/devworkspace_controller_test.go
+++ b/controllers/workspace/devworkspace_controller_test.go
@@ -1729,6 +1729,53 @@ var _ = Describe("DevWorkspace Controller", func() {
 			}, 30*time.Second, 1*time.Second).Should(Succeed(),
 				"init-persistent-home should have custom-arg-123, non-empty VolumeMounts, and non-empty Image")
 		})
+		It("InvalidCommandFailsWorkspace: invalid init-persistent-home command causes workspace to fail", func() {
+			By("Saving original InitContainers and PersistUserHome from testControllerCfg")
+			savedInitContainers := testControllerCfg.Workspace.InitContainers
+			if testControllerCfg.Workspace.PersistUserHome == nil {
+				testControllerCfg.Workspace.PersistUserHome = &controllerv1alpha1.PersistentHomeConfig{}
+			}
+			savedPersistEnabled := testControllerCfg.Workspace.PersistUserHome.Enabled
+			DeferCleanup(func() {
+				testControllerCfg.Workspace.InitContainers = nil
+				testControllerCfg.Workspace.PersistUserHome.Enabled = savedPersistEnabled
+				config.SetGlobalConfigForTesting(testControllerCfg)
+			})
+
+			By("Configuring testControllerCfg with invalid init-persistent-home command and PersistUserHome enabled")
+			testControllerCfg.Workspace.InitContainers = []corev1.Container{
+				{
+					Name:    constants.HomeInitComponentName,
+					Command: []string{"/bin/bash", "-c"},
+				},
+			}
+			testControllerCfg.Workspace.PersistUserHome.Enabled = ptr.To(true)
+			config.SetGlobalConfigForTesting(testControllerCfg)
+
+			By("Creating DevWorkspace")
+			createDevWorkspace(devWorkspaceName, "test-devworkspace.yaml")
+			dwNamespacedName := namespacedName(devWorkspaceName, testNamespace)
+
+			By("Checking that DevWorkspace enters Failed phase with expected message")
+			workspace := &dw.DevWorkspace{}
+			Eventually(func() (dw.DevWorkspacePhase, error) {
+				if err := k8sClient.Get(ctx, dwNamespacedName, workspace); err != nil {
+					return "", err
+				}
+				GinkgoWriter.Printf("Waiting for DevWorkspace to fail -- Phase: %s, Message: %s\n",
+					workspace.Status.Phase, workspace.Status.Message)
+				return workspace.Status.Phase, nil
+			}, 30*time.Second, 1*time.Second).Should(Equal(dw.DevWorkspaceStatusFailed),
+				"DevWorkspace should fail due to invalid init-persistent-home command")
+
+			Expect(workspace.Status.Message).Should(ContainSubstring(
+				"Invalid init-persistent-home container: command must be exactly [/bin/sh, -c]"),
+				"Failure message should describe the invalid command error")
+
+			// Restore saved value
+			testControllerCfg.Workspace.InitContainers = savedInitContainers
+		})
+
 	})
 
 })

--- a/controllers/workspace/devworkspace_controller_test.go
+++ b/controllers/workspace/devworkspace_controller_test.go
@@ -1776,6 +1776,76 @@ var _ = Describe("DevWorkspace Controller", func() {
 			testControllerCfg.Workspace.InitContainers = savedInitContainers
 		})
 
+		It("AdditionalInitContainersInjected: additional non-home init containers are injected after init-persistent-home", func() {
+			By("Saving original InitContainers and PersistUserHome from testControllerCfg")
+			savedInitContainers := testControllerCfg.Workspace.InitContainers
+			DeferCleanup(func() {
+				testControllerCfg.Workspace.InitContainers = nil
+				config.SetGlobalConfigForTesting(testControllerCfg)
+			})
+
+			By("Saving and enabling PersistUserHome")
+			if testControllerCfg.Workspace.PersistUserHome == nil {
+				testControllerCfg.Workspace.PersistUserHome = &controllerv1alpha1.PersistentHomeConfig{}
+			}
+			savedPersistEnabled := testControllerCfg.Workspace.PersistUserHome.Enabled
+			DeferCleanup(func() {
+				testControllerCfg.Workspace.PersistUserHome.Enabled = savedPersistEnabled
+				config.SetGlobalConfigForTesting(testControllerCfg)
+			})
+
+			By("Configuring testControllerCfg with home init container and custom-tooling init container")
+			testControllerCfg.Workspace.InitContainers = []corev1.Container{
+				{Name: constants.HomeInitComponentName, Args: []string{"custom-arg-456"}},
+				{Name: "custom-tooling", Image: "busybox:latest", Command: []string{"/bin/sh"}, Args: []string{"-c", "echo tooling-ready"}},
+			}
+			testControllerCfg.Workspace.PersistUserHome.Enabled = ptr.To(true)
+			_ = savedInitContainers
+			config.SetGlobalConfigForTesting(testControllerCfg)
+
+			By("Creating DevWorkspace")
+			createDevWorkspace(devWorkspaceName, "test-devworkspace.yaml")
+			devworkspace := getExistingDevWorkspace(devWorkspaceName)
+			workspaceID := devworkspace.Status.DevWorkspaceId
+
+			By("Manually making Routing ready to continue")
+			markRoutingReady(testURL, common.DevWorkspaceRoutingName(workspaceID))
+
+			By("Setting the deployment to have 1 ready replica")
+			markDeploymentReady(common.DeploymentName(workspaceID))
+
+			By("Verifying both init containers are present and init-persistent-home appears before custom-tooling")
+			deploy := &appsv1.Deployment{}
+			deployNN := namespacedName(common.DeploymentName(workspaceID), testNamespace)
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, deployNN, deploy); err != nil {
+					return fmt.Errorf("failed to get deployment: %w", err)
+				}
+				initContainers := deploy.Spec.Template.Spec.InitContainers
+				homeIdx := -1
+				toolingIdx := -1
+				for i, c := range initContainers {
+					if c.Name == constants.HomeInitComponentName {
+						homeIdx = i
+					}
+					if c.Name == "custom-tooling" {
+						toolingIdx = i
+					}
+				}
+				if homeIdx == -1 {
+					return fmt.Errorf("init container not found: init-persistent-home")
+				}
+				if toolingIdx == -1 {
+					return fmt.Errorf("init container not found: custom-tooling")
+				}
+				if homeIdx >= toolingIdx {
+					return fmt.Errorf("expected init-persistent-home (idx %d) before custom-tooling (idx %d)", homeIdx, toolingIdx)
+				}
+				return nil
+			}, 30*time.Second, 1*time.Second).Should(Succeed(),
+				"init-persistent-home should appear before custom-tooling and both containers should be present")
+		})
+
 	})
 
 })

--- a/controllers/workspace/devworkspace_controller_test.go
+++ b/controllers/workspace/devworkspace_controller_test.go
@@ -1776,6 +1776,57 @@ var _ = Describe("DevWorkspace Controller", func() {
 			testControllerCfg.Workspace.InitContainers = savedInitContainers
 		})
 
+		It("BackwardCompatNoCustomInit: workspace starts normally when no custom init containers are configured", func() {
+			By("Ensuring testControllerCfg has nil InitContainers (backward-compat scenario)")
+			savedInitContainers := testControllerCfg.Workspace.InitContainers
+			DeferCleanup(func() {
+				testControllerCfg.Workspace.InitContainers = savedInitContainers
+				config.SetGlobalConfigForTesting(testControllerCfg)
+			})
+
+			By("Saving and enabling PersistUserHome")
+			if testControllerCfg.Workspace.PersistUserHome == nil {
+				testControllerCfg.Workspace.PersistUserHome = &controllerv1alpha1.PersistentHomeConfig{}
+			}
+			savedPersistEnabled := testControllerCfg.Workspace.PersistUserHome.Enabled
+			DeferCleanup(func() {
+				testControllerCfg.Workspace.PersistUserHome.Enabled = savedPersistEnabled
+				config.SetGlobalConfigForTesting(testControllerCfg)
+			})
+
+			testControllerCfg.Workspace.InitContainers = nil
+			testControllerCfg.Workspace.PersistUserHome.Enabled = ptr.To(true)
+			config.SetGlobalConfigForTesting(testControllerCfg)
+
+			By("Creating DevWorkspace")
+			createDevWorkspace(devWorkspaceName, "test-devworkspace.yaml")
+			devworkspace := getExistingDevWorkspace(devWorkspaceName)
+			workspaceID := devworkspace.Status.DevWorkspaceId
+
+			By("Manually making Routing ready to continue")
+			markRoutingReady(testURL, common.DevWorkspaceRoutingName(workspaceID))
+
+			By("Setting the deployment to have 1 ready replica")
+			markDeploymentReady(common.DeploymentName(workspaceID))
+
+			By("Verifying the default init-persistent-home container is present in the deployment")
+			deploy := &appsv1.Deployment{}
+			deployNN := namespacedName(common.DeploymentName(workspaceID), testNamespace)
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, deployNN, deploy); err != nil {
+					return fmt.Errorf("failed to get deployment: %w", err)
+				}
+				for _, c := range deploy.Spec.Template.Spec.InitContainers {
+					if c.Name == constants.HomeInitComponentName {
+						return nil
+					}
+				}
+				return fmt.Errorf("init container %q not found in deployment; init containers: %v",
+					constants.HomeInitComponentName, deploy.Spec.Template.Spec.InitContainers)
+			}, 30*time.Second, 1*time.Second).Should(Succeed(),
+				"default init-persistent-home should be present when no custom init containers are configured")
+		})
+
 		It("AdditionalInitContainersInjected: additional non-home init containers are injected after init-persistent-home", func() {
 			By("Saving original InitContainers and PersistUserHome from testControllerCfg")
 			savedInitContainers := testControllerCfg.Workspace.InitContainers

--- a/controllers/workspace/devworkspace_controller_test.go
+++ b/controllers/workspace/devworkspace_controller_test.go
@@ -1633,4 +1633,102 @@ var _ = Describe("DevWorkspace Controller", func() {
 		})
 	})
 
+	Context("Custom init container overrides", func() {
+		const testURL = "test-url"
+
+		BeforeEach(func() {
+			workspacecontroller.SetupHttpClientsForTesting(&http.Client{
+				Transport: &testutil.TestRoundTripper{
+					Data: map[string]testutil.TestResponse{
+						fmt.Sprintf("%s/healthz", testURL): {
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			})
+		})
+
+		AfterEach(func() {
+			deleteDevWorkspace(devWorkspaceName)
+			workspacecontroller.SetupHttpClientsForTesting(getBasicTestHttpClient())
+		})
+
+		It("CustomInitPersistentHome: custom init-persistent-home override sets args, volume mounts and image", func() {
+			By("Saving original InitContainers from testControllerCfg")
+			savedInitContainers := testControllerCfg.Workspace.InitContainers
+			DeferCleanup(func() {
+				testControllerCfg.Workspace.InitContainers = savedInitContainers
+				config.SetGlobalConfigForTesting(testControllerCfg)
+			})
+
+			By("Saving and enabling PersistUserHome")
+			if testControllerCfg.Workspace.PersistUserHome == nil {
+				testControllerCfg.Workspace.PersistUserHome = &controllerv1alpha1.PersistentHomeConfig{}
+			}
+			savedPersistEnabled := testControllerCfg.Workspace.PersistUserHome.Enabled
+			DeferCleanup(func() {
+				testControllerCfg.Workspace.PersistUserHome.Enabled = savedPersistEnabled
+				config.SetGlobalConfigForTesting(testControllerCfg)
+			})
+
+			By("Configuring testControllerCfg with custom init-persistent-home")
+			testControllerCfg.Workspace.InitContainers = []corev1.Container{
+				{
+					Name: constants.HomeInitComponentName,
+					Args: []string{"custom-arg-123"},
+				},
+			}
+			testControllerCfg.Workspace.PersistUserHome.Enabled = ptr.To(true)
+			config.SetGlobalConfigForTesting(testControllerCfg)
+
+			By("Creating DevWorkspace")
+			createDevWorkspace(devWorkspaceName, "test-devworkspace.yaml")
+			devworkspace := getExistingDevWorkspace(devWorkspaceName)
+			workspaceID := devworkspace.Status.DevWorkspaceId
+
+			By("Manually making Routing ready to continue")
+			markRoutingReady(testURL, common.DevWorkspaceRoutingName(workspaceID))
+
+			By("Setting the deployment to have 1 ready replica")
+			markDeploymentReady(common.DeploymentName(workspaceID))
+
+			By("Verifying init-persistent-home has custom-arg-123, non-empty VolumeMounts, and non-empty Image")
+			deploy := &appsv1.Deployment{}
+			deployNN := namespacedName(common.DeploymentName(workspaceID), testNamespace)
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, deployNN, deploy); err != nil {
+					return fmt.Errorf("failed to get deployment: %w", err)
+				}
+				var homeInit *corev1.Container
+				for i := range deploy.Spec.Template.Spec.InitContainers {
+					if deploy.Spec.Template.Spec.InitContainers[i].Name == constants.HomeInitComponentName {
+						homeInit = &deploy.Spec.Template.Spec.InitContainers[i]
+						break
+					}
+				}
+				if homeInit == nil {
+					return fmt.Errorf("init container %q not found in deployment init containers", constants.HomeInitComponentName)
+				}
+				found := false
+				for _, arg := range homeInit.Args {
+					if arg == "custom-arg-123" {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return fmt.Errorf("expected arg %q not found in init container args %v", "custom-arg-123", homeInit.Args)
+				}
+				if len(homeInit.VolumeMounts) == 0 {
+					return fmt.Errorf("expected non-empty VolumeMounts on init-persistent-home, got none")
+				}
+				if homeInit.Image == "" {
+					return fmt.Errorf("expected non-empty Image on init-persistent-home, got empty string")
+				}
+				return nil
+			}, 30*time.Second, 1*time.Second).Should(Succeed(),
+				"init-persistent-home should have custom-arg-123, non-empty VolumeMounts, and non-empty Image")
+		})
+	})
+
 })

--- a/controllers/workspace/devworkspace_init_containers_test.go
+++ b/controllers/workspace/devworkspace_init_containers_test.go
@@ -1,0 +1,325 @@
+// Copyright (c) 2019-2025 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers_test
+
+import (
+	"time"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/config"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+// createInitContainerTestDW creates a DevWorkspace for init container tests and waits
+// for it to have a DevWorkspace ID assigned. Unlike createDevWorkspace, this function
+// correctly uses the provided name (not the hardcoded devWorkspaceName constant).
+func createInitContainerTestDW(name, fromFile string) {
+	By("Loading DevWorkspace from test file")
+	devworkspace := &dw.DevWorkspace{}
+	Expect(loadObjectFromFile(name, devworkspace, fromFile)).Should(Succeed())
+
+	By("Creating DevWorkspace on cluster")
+	Expect(k8sClient.Create(ctx, devworkspace)).Should(Succeed())
+
+	By("Waiting for DevWorkspace ID to be assigned")
+	createdDW := &dw.DevWorkspace{}
+	Eventually(func() bool {
+		if err := k8sClient.Get(ctx, namespacedName(name, testNamespace), createdDW); err != nil {
+			return false
+		}
+		return createdDW.Status.DevWorkspaceId != ""
+	}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(),
+		"DevWorkspace %s should have a DevWorkspaceId assigned", name)
+}
+
+// getInitContainerTestDW gets an existing DevWorkspace for init container tests.
+func getInitContainerTestDW(name string) *dw.DevWorkspace {
+	By("Getting existing DevWorkspace")
+	dw := &dw.DevWorkspace{}
+	dwNN := namespacedName(name, testNamespace)
+	Eventually(func() (string, error) {
+		if err := k8sClient.Get(ctx, dwNN, dw); err != nil {
+			return "", err
+		}
+		return dw.Status.DevWorkspaceId, nil
+	}, timeout, interval).Should(Not(BeEmpty()),
+		"DevWorkspace %s should have a DevWorkspaceId", name)
+	return dw
+}
+
+var _ = Describe("Init Container Injection", func() {
+	const initContainerTestDWName = "test-init-container-dw"
+
+	AfterEach(func() {
+		deleteDevWorkspace(initContainerTestDWName)
+		config.SetGlobalConfigForTesting(nil)
+	})
+
+	Context("DWOC InitContainers injection", func() {
+
+		It("Scenario 1: No DWOC init containers — devfile containers unchanged", func() {
+			By("Setting global config with no InitContainers")
+			config.SetGlobalConfigForTesting(&controllerv1alpha1.OperatorConfiguration{
+				Workspace: &controllerv1alpha1.WorkspaceConfig{},
+			})
+
+			By("Creating DevWorkspace")
+			createInitContainerTestDW(initContainerTestDWName, "test-devworkspace.yaml")
+			devworkspace := getInitContainerTestDW(initContainerTestDWName)
+			workspaceID := devworkspace.Status.DevWorkspaceId
+
+			By("Manually making Routing ready to continue")
+			markRoutingReady("test-url", common.DevWorkspaceRoutingName(workspaceID))
+
+			By("Waiting for Deployment to be created")
+			deploy := &appsv1.Deployment{}
+			deployNN := namespacedName(common.DeploymentName(workspaceID), testNamespace)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, deployNN, deploy)
+			}, timeout, interval).Should(Succeed(), "Getting workspace deployment from cluster")
+
+			By("Checking that no DWOC-injected init containers are present")
+			for _, initContainer := range deploy.Spec.Template.Spec.InitContainers {
+				Expect(initContainer.Name).ShouldNot(Equal(constants.HomeInitComponentName),
+					"init-persistent-home should not be present when no DWOC init containers are configured")
+			}
+		})
+
+		It("Scenario 2: DWOC has custom init-persistent-home with valid args — merged into pod additions", func() {
+			By("Setting global config with init-persistent-home having valid args")
+			config.SetGlobalConfigForTesting(&controllerv1alpha1.OperatorConfiguration{
+				Workspace: &controllerv1alpha1.WorkspaceConfig{
+					PersistUserHome: &controllerv1alpha1.PersistentHomeConfig{
+						Enabled: ptr.To(true),
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name: constants.HomeInitComponentName,
+							Args: []string{"echo 'custom persistent home init'"},
+						},
+					},
+				},
+			})
+
+			By("Creating DevWorkspace")
+			createInitContainerTestDW(initContainerTestDWName, "test-devworkspace.yaml")
+			devworkspace := getInitContainerTestDW(initContainerTestDWName)
+			workspaceID := devworkspace.Status.DevWorkspaceId
+
+			By("Manually making Routing ready to continue")
+			markRoutingReady("test-url", common.DevWorkspaceRoutingName(workspaceID))
+
+			By("Waiting for Deployment to be created")
+			deploy := &appsv1.Deployment{}
+			deployNN := namespacedName(common.DeploymentName(workspaceID), testNamespace)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, deployNN, deploy)
+			}, timeout, interval).Should(Succeed(), "Getting workspace deployment from cluster")
+
+			By("Checking that init-persistent-home is present in init containers")
+			var homeInitContainer *corev1.Container
+			for i := range deploy.Spec.Template.Spec.InitContainers {
+				if deploy.Spec.Template.Spec.InitContainers[i].Name == constants.HomeInitComponentName {
+					homeInitContainer = &deploy.Spec.Template.Spec.InitContainers[i]
+					break
+				}
+			}
+			Expect(homeInitContainer).ShouldNot(BeNil(),
+				"init-persistent-home container should be present in deployment init containers")
+			Expect(homeInitContainer.Command).Should(Equal([]string{"/bin/sh", "-c"}),
+				"init-persistent-home container should have default command set by EnsureHomeInitContainerFields")
+		})
+
+		It("Scenario 3: DWOC has custom init-persistent-home with wrong command — workspace fails", func() {
+			By("Setting global config with init-persistent-home having invalid command")
+			config.SetGlobalConfigForTesting(&controllerv1alpha1.OperatorConfiguration{
+				Workspace: &controllerv1alpha1.WorkspaceConfig{
+					PersistUserHome: &controllerv1alpha1.PersistentHomeConfig{
+						Enabled: ptr.To(true),
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:    constants.HomeInitComponentName,
+							Command: []string{"/wrong/command"},
+							Args:    []string{"echo 'custom persistent home init'"},
+						},
+					},
+				},
+			})
+
+			By("Creating DevWorkspace")
+			createInitContainerTestDW(initContainerTestDWName, "test-devworkspace.yaml")
+			dwNamespacedName := namespacedName(initContainerTestDWName, testNamespace)
+
+			By("Checking that DevWorkspace enters Failed phase")
+			currDW := &dw.DevWorkspace{}
+			Eventually(func() (dw.DevWorkspacePhase, error) {
+				if err := k8sClient.Get(ctx, dwNamespacedName, currDW); err != nil {
+					return "", err
+				}
+				GinkgoWriter.Printf("Waiting for DevWorkspace to fail -- Phase: %s, Message: %s\n",
+					currDW.Status.Phase, currDW.Status.Message)
+				return currDW.Status.Phase, nil
+			}, timeout, interval).Should(Equal(dw.DevWorkspaceStatusFailed),
+				"DevWorkspace should fail due to invalid init-persistent-home command")
+
+			By("Checking that the failure message references invalid command")
+			Expect(currDW.Status.Message).Should(ContainSubstring(
+				"Invalid init-persistent-home container: command must be exactly [/bin/sh, -c]"),
+				"Failure message should describe the invalid command error")
+		})
+
+		It("Scenario 4: DWOC has non-home init container — appended after base", func() {
+			By("Setting global config with a custom non-home init container")
+			config.SetGlobalConfigForTesting(&controllerv1alpha1.OperatorConfiguration{
+				Workspace: &controllerv1alpha1.WorkspaceConfig{
+					InitContainers: []corev1.Container{
+						{
+							Name:  "custom-init-container",
+							Image: "busybox:latest",
+							Args:  []string{"echo 'custom non-home init'"},
+						},
+					},
+				},
+			})
+
+			By("Creating DevWorkspace")
+			createInitContainerTestDW(initContainerTestDWName, "test-devworkspace.yaml")
+			devworkspace := getInitContainerTestDW(initContainerTestDWName)
+			workspaceID := devworkspace.Status.DevWorkspaceId
+
+			By("Manually making Routing ready to continue")
+			markRoutingReady("test-url", common.DevWorkspaceRoutingName(workspaceID))
+
+			By("Waiting for Deployment to be created")
+			deploy := &appsv1.Deployment{}
+			deployNN := namespacedName(common.DeploymentName(workspaceID), testNamespace)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, deployNN, deploy)
+			}, timeout, interval).Should(Succeed(), "Getting workspace deployment from cluster")
+
+			By("Checking that custom init container is present in deployment init containers")
+			initContainerNames := make([]string, 0, len(deploy.Spec.Template.Spec.InitContainers))
+			for _, c := range deploy.Spec.Template.Spec.InitContainers {
+				initContainerNames = append(initContainerNames, c.Name)
+			}
+
+			Expect(initContainerNames).Should(ContainElement("custom-init-container"),
+				"custom-init-container should be present in deployment init containers")
+
+			By("Checking that custom init container appears after base init containers from devfile")
+			customInitIdx := -1
+			for i, name := range initContainerNames {
+				if name == "custom-init-container" {
+					customInitIdx = i
+					break
+				}
+			}
+			Expect(customInitIdx).Should(BeNumerically(">", -1),
+				"custom-init-container should be found in init containers list")
+
+			// Verify any project-clone container (base init) comes before custom-init-container
+			for i, name := range initContainerNames {
+				if name == "project-clone" {
+					Expect(i).Should(BeNumerically("<", customInitIdx),
+						"project-clone init container should come before custom-init-container")
+				}
+			}
+		})
+
+		It("Scenario 5: persistUserHome.enabled=false — init-persistent-home from DWOC skipped", func() {
+			By("Setting global config with persistUserHome disabled but init-persistent-home in InitContainers")
+			config.SetGlobalConfigForTesting(&controllerv1alpha1.OperatorConfiguration{
+				Workspace: &controllerv1alpha1.WorkspaceConfig{
+					PersistUserHome: &controllerv1alpha1.PersistentHomeConfig{
+						Enabled: ptr.To(false),
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name: constants.HomeInitComponentName,
+							Args: []string{"echo 'custom persistent home init'"},
+						},
+					},
+				},
+			})
+
+			By("Creating DevWorkspace")
+			createInitContainerTestDW(initContainerTestDWName, "test-devworkspace.yaml")
+			devworkspace := getInitContainerTestDW(initContainerTestDWName)
+			workspaceID := devworkspace.Status.DevWorkspaceId
+
+			By("Manually making Routing ready to continue")
+			markRoutingReady("test-url", common.DevWorkspaceRoutingName(workspaceID))
+
+			By("Waiting for Deployment to be created")
+			deploy := &appsv1.Deployment{}
+			deployNN := namespacedName(common.DeploymentName(workspaceID), testNamespace)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, deployNN, deploy)
+			}, timeout, interval).Should(Succeed(), "Getting workspace deployment from cluster")
+
+			By("Checking that init-persistent-home is NOT present in init containers")
+			for _, initContainer := range deploy.Spec.Template.Spec.InitContainers {
+				Expect(initContainer.Name).ShouldNot(Equal(constants.HomeInitComponentName),
+					"init-persistent-home should be skipped when persistUserHome.enabled=false")
+			}
+		})
+
+		It("Scenario 6: disableInitContainer=true — init-persistent-home from DWOC skipped", func() {
+			By("Setting global config with disableInitContainer=true and init-persistent-home in InitContainers")
+			config.SetGlobalConfigForTesting(&controllerv1alpha1.OperatorConfiguration{
+				Workspace: &controllerv1alpha1.WorkspaceConfig{
+					PersistUserHome: &controllerv1alpha1.PersistentHomeConfig{
+						Enabled:              ptr.To(true),
+						DisableInitContainer: ptr.To(true),
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name: constants.HomeInitComponentName,
+							Args: []string{"echo 'custom persistent home init'"},
+						},
+					},
+				},
+			})
+
+			By("Creating DevWorkspace")
+			createInitContainerTestDW(initContainerTestDWName, "test-devworkspace.yaml")
+			devworkspace := getInitContainerTestDW(initContainerTestDWName)
+			workspaceID := devworkspace.Status.DevWorkspaceId
+
+			By("Manually making Routing ready to continue")
+			markRoutingReady("test-url", common.DevWorkspaceRoutingName(workspaceID))
+
+			By("Waiting for Deployment to be created")
+			deploy := &appsv1.Deployment{}
+			deployNN := namespacedName(common.DeploymentName(workspaceID), testNamespace)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, deployNN, deploy)
+			}, timeout, interval).Should(Succeed(), "Getting workspace deployment from cluster")
+
+			By("Checking that init-persistent-home is NOT present in init containers")
+			for _, initContainer := range deploy.Spec.Template.Spec.InitContainers {
+				Expect(initContainer.Name).ShouldNot(Equal(constants.HomeInitComponentName),
+					"init-persistent-home should be skipped when disableInitContainer=true")
+			}
+		})
+	})
+})

--- a/controllers/workspace/suite_test.go
+++ b/controllers/workspace/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"testing"
 
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	dwv1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
@@ -121,6 +122,9 @@ var _ = BeforeSuite(func() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:   scheme.Scheme,
 		NewCache: cacheFunc,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // Disable metrics server in tests to avoid port conflicts
+		},
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port: 9443,
 		}),

--- a/controllers/workspace/testdata/test-devworkspace-init-containers.yaml
+++ b/controllers/workspace/testdata/test-devworkspace-init-containers.yaml
@@ -1,0 +1,24 @@
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  labels:
+    controller.devfile.io/creator: ""
+spec:
+  started: true
+  routingClass: 'basic'
+  template:
+    projects:
+      - name: web-nodejs-sample
+        git:
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
+    components:
+      - name: web-terminal
+        container:
+          image: quay.io/wto/web-terminal-tooling:latest
+          memoryLimit: 512Mi
+          mountSources: true
+          command:
+           - "tail"
+           - "-f"
+           - "/dev/null"

--- a/pkg/library/home/custom_init.go
+++ b/pkg/library/home/custom_init.go
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2019-2025 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package home
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+)
+
+// EnsureHomeInitContainerFields validates and sets required fields on an init-persistent-home container.
+// If container.Command is nil, it is set to ["/bin/sh", "-c"]. If container.Command is non-nil and
+// does not equal ["/bin/sh", "-c"] exactly, an error is returned. The function also ensures that
+// container.VolumeMounts includes a mount for the persistent-home volume.
+func EnsureHomeInitContainerFields(container *corev1.Container) error {
+	if container.Command == nil {
+		container.Command = []string{"/bin/sh", "-c"}
+	} else if len(container.Command) != 2 || container.Command[0] != "/bin/sh" || container.Command[1] != "-c" {
+		return fmt.Errorf("Invalid init-persistent-home container: command must be exactly [/bin/sh, -c]")
+	}
+
+	// Ensure the persistent-home volume mount is present
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == constants.HomeVolumeName {
+			// Mount already present; return without adding a duplicate
+			return nil
+		}
+	}
+
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      constants.HomeVolumeName,
+		MountPath: constants.HomeUserDirectory,
+	})
+
+	return nil
+}

--- a/pkg/library/home/custom_init_test.go
+++ b/pkg/library/home/custom_init_test.go
@@ -36,7 +36,7 @@ func TestCustomInitPersistentHome(t *testing.T) {
 		expectCustomInitSkipped bool
 	}{
 		{
-			name: "Skips default init when custom init-persistent-home is provided in DWOC",
+			name: "Uses custom init when custom init-persistent-home is provided in DWOC",
 			workspace: &common.DevWorkspaceWithConfig{
 				DevWorkspace: &dw.DevWorkspace{
 					Spec: dw.DevWorkspaceSpec{
@@ -72,7 +72,9 @@ func TestCustomInitPersistentHome(t *testing.T) {
 					},
 				},
 			},
-			expectDefaultInitAdded: false,
+			// Custom init-persistent-home is added as a component named HomeInitComponentName
+			// (replacing the default stow-based init), so the component IS present.
+			expectDefaultInitAdded: true,
 		},
 		{
 			name: "Adds default init when no custom init-persistent-home is provided",

--- a/pkg/library/home/custom_init_test.go
+++ b/pkg/library/home/custom_init_test.go
@@ -36,7 +36,7 @@ func TestCustomInitPersistentHome(t *testing.T) {
 		expectCustomInitSkipped bool
 	}{
 		{
-			name: "Adds default init when custom init-persistent-home is provided",
+			name: "Skips default init when custom init-persistent-home is provided in DWOC",
 			workspace: &common.DevWorkspaceWithConfig{
 				DevWorkspace: &dw.DevWorkspace{
 					Spec: dw.DevWorkspaceSpec{
@@ -72,7 +72,7 @@ func TestCustomInitPersistentHome(t *testing.T) {
 					},
 				},
 			},
-			expectDefaultInitAdded: true,
+			expectDefaultInitAdded: false,
 		},
 		{
 			name: "Adds default init when no custom init-persistent-home is provided",

--- a/pkg/library/home/persistentHome.go
+++ b/pkg/library/home/persistentHome.go
@@ -325,24 +325,3 @@ func inferInitContainer(dwTemplateSpec *v1alpha2.DevWorkspaceTemplateSpec) *v1al
 	return nil
 }
 
-// EnsureHomeInitContainerFields enforces the correct image and VolumeMount on an
-// init-persistent-home container regardless of what custom config provides.
-// If container.Image is empty, it is set to image.
-// The VolumeMount for homeVolumeName -> /home/user/ is always set.
-func EnsureHomeInitContainerFields(container *corev1.Container, image, homeVolumeName string) {
-	if container.Image == "" {
-		container.Image = image
-	}
-	// Ensure the persistent-home volume mount is always present and correct
-	mountPath := constants.HomeUserDirectory
-	for i, vm := range container.VolumeMounts {
-		if vm.Name == homeVolumeName {
-			container.VolumeMounts[i].MountPath = mountPath
-			return
-		}
-	}
-	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-		Name:      homeVolumeName,
-		MountPath: mountPath,
-	})
-}

--- a/pkg/library/home/persistentHome.go
+++ b/pkg/library/home/persistentHome.go
@@ -62,11 +62,26 @@ func AddPersistentHomeVolume(workspace *common.DevWorkspaceWithConfig) (*v1alpha
 		Path: constants.HomeUserDirectory,
 	}
 
-	// Add default init container only if not disabled and no custom init is configured
-	if workspace.Config.Workspace.PersistUserHome.DisableInitContainer == nil || !*workspace.Config.Workspace.PersistUserHome.DisableInitContainer {
-		err := addInitContainer(dwTemplateSpecCopy)
-		if err != nil {
-			return nil, fmt.Errorf("failed to add init container for home persistence setup: %w", err)
+	// DisableInitContainer: true suppresses init container creation entirely,
+	// even if a custom init-persistent-home is configured in DWOC.
+	disableInitContainer := workspace.Config.Workspace.PersistUserHome.DisableInitContainer != nil &&
+		*workspace.Config.Workspace.PersistUserHome.DisableInitContainer
+
+	if !disableInitContainer {
+		// Check whether a custom init-persistent-home is configured in DWOC
+		customContainer := findCustomInitContainer(workspace)
+		if customContainer != nil {
+			// Use custom container with its Args instead of the default stow script
+			err := addCustomInitContainer(dwTemplateSpecCopy, customContainer)
+			if err != nil {
+				return nil, fmt.Errorf("failed to add custom init container for home persistence setup: %w", err)
+			}
+		} else {
+			// No custom container: use default stow-based init script (backward compatibility)
+			err := addInitContainer(dwTemplateSpecCopy)
+			if err != nil {
+				return nil, fmt.Errorf("failed to add init container for home persistence setup: %w", err)
+			}
 		}
 	}
 
@@ -140,6 +155,69 @@ func hasInitPersistentHomeInConfig(workspace *common.DevWorkspaceWithConfig) boo
 	}
 
 	return false
+}
+
+// findCustomInitContainer searches workspace.Config.Workspace.InitContainers for
+// a container named HomeInitComponentName and returns a pointer to it if found.
+func findCustomInitContainer(workspace *common.DevWorkspaceWithConfig) *corev1.Container {
+	if workspace.Config == nil || workspace.Config.Workspace == nil {
+		return nil
+	}
+	for i := range workspace.Config.Workspace.InitContainers {
+		if workspace.Config.Workspace.InitContainers[i].Name == constants.HomeInitComponentName {
+			return &workspace.Config.Workspace.InitContainers[i]
+		}
+	}
+	return nil
+}
+
+// addCustomInitContainer adds an init-persistent-home devfile component whose Args
+// come from the DWOC-provided custom corev1.Container instead of the default stow script.
+func addCustomInitContainer(dwTemplateSpec *v1alpha2.DevWorkspaceTemplateSpec, custom *corev1.Container) error {
+	if initComponentExists(dwTemplateSpec) {
+		return fmt.Errorf("component named %s already exists in the devworkspace", constants.HomeInitComponentName)
+	}
+	if initCommandExists(dwTemplateSpec) {
+		return fmt.Errorf("command with id %s already exists in the devworkspace", constants.HomeInitEventId)
+	}
+	if initEventExists(dwTemplateSpec) {
+		return fmt.Errorf("event with id %s already exists in the devworkspace", constants.HomeInitEventId)
+	}
+
+	initContainer := &v1alpha2.Container{
+		Image:   custom.Image,
+		Command: custom.Command,
+		Args:    custom.Args,
+	}
+	// Fallback: if no image is set in the custom container, infer from workspace components
+	if initContainer.Image == "" {
+		initContainer.Image = InferWorkspaceImage(dwTemplateSpec)
+	}
+	// Fallback: if no command set in the custom container, use default shell invocation
+	if len(initContainer.Command) == 0 {
+		initContainer.Command = []string{"/bin/sh", "-c"}
+	}
+
+	addInitContainerComponent(dwTemplateSpec, initContainer)
+
+	if dwTemplateSpec.Commands == nil {
+		dwTemplateSpec.Commands = []v1alpha2.Command{}
+	}
+	if dwTemplateSpec.Events == nil {
+		dwTemplateSpec.Events = &v1alpha2.Events{}
+	}
+
+	dwTemplateSpec.Commands = append(dwTemplateSpec.Commands, v1alpha2.Command{
+		Id: constants.HomeInitEventId,
+		CommandUnion: v1alpha2.CommandUnion{
+			Apply: &v1alpha2.ApplyCommand{
+				Component: constants.HomeInitComponentName,
+			},
+		},
+	})
+	dwTemplateSpec.Events.PreStart = append(dwTemplateSpec.Events.PreStart, constants.HomeInitEventId)
+
+	return nil
 }
 
 func addInitContainer(dwTemplateSpec *v1alpha2.DevWorkspaceTemplateSpec) error {
@@ -247,16 +325,24 @@ func inferInitContainer(dwTemplateSpec *v1alpha2.DevWorkspaceTemplateSpec) *v1al
 	return nil
 }
 
-// EnsureHomeInitContainerFields ensures that an init-persistent-home container has
-// the correct Command and VolumeMounts.
-func EnsureHomeInitContainerFields(c *corev1.Container) error {
-	// Set default command only if not provided
-	if len(c.Command) == 0 {
-		c.Command = []string{"/bin/sh", "-c"}
+// EnsureHomeInitContainerFields enforces the correct image and VolumeMount on an
+// init-persistent-home container regardless of what custom config provides.
+// If container.Image is empty, it is set to image.
+// The VolumeMount for homeVolumeName -> /home/user/ is always set.
+func EnsureHomeInitContainerFields(container *corev1.Container, image, homeVolumeName string) {
+	if container.Image == "" {
+		container.Image = image
 	}
-	c.VolumeMounts = []corev1.VolumeMount{{
-		Name:      constants.HomeVolumeName,
-		MountPath: constants.HomeUserDirectory,
-	}}
-	return nil
+	// Ensure the persistent-home volume mount is always present and correct
+	mountPath := constants.HomeUserDirectory
+	for i, vm := range container.VolumeMounts {
+		if vm.Name == homeVolumeName {
+			container.VolumeMounts[i].MountPath = mountPath
+			return
+		}
+	}
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      homeVolumeName,
+		MountPath: mountPath,
+	})
 }

--- a/pkg/library/home/persistentHome.go
+++ b/pkg/library/home/persistentHome.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	devfilevalidation "github.com/devfile/api/v2/pkg/validation"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
 	"github.com/devfile/devworkspace-operator/pkg/common"
@@ -62,8 +61,10 @@ func AddPersistentHomeVolume(workspace *common.DevWorkspaceWithConfig) (*v1alpha
 		Path: constants.HomeUserDirectory,
 	}
 
-	// Add default init container only if not disabled and no custom init is configured
-	if workspace.Config.Workspace.PersistUserHome.DisableInitContainer == nil || !*workspace.Config.Workspace.PersistUserHome.DisableInitContainer {
+	// Add default init container only if not disabled and no custom init-persistent-home is configured in DWOC
+	disableInit := workspace.Config.Workspace.PersistUserHome.DisableInitContainer != nil && *workspace.Config.Workspace.PersistUserHome.DisableInitContainer
+	hasCustomHomeInit := hasInitPersistentHomeInConfig(workspace)
+	if !disableInit && !hasCustomHomeInit {
 		err := addInitContainer(dwTemplateSpecCopy)
 		if err != nil {
 			return nil, fmt.Errorf("failed to add init container for home persistence setup: %w", err)
@@ -247,16 +248,3 @@ func inferInitContainer(dwTemplateSpec *v1alpha2.DevWorkspaceTemplateSpec) *v1al
 	return nil
 }
 
-// EnsureHomeInitContainerFields ensures that an init-persistent-home container has
-// the correct Command and VolumeMounts.
-func EnsureHomeInitContainerFields(c *corev1.Container) error {
-	// Set default command only if not provided
-	if len(c.Command) == 0 {
-		c.Command = []string{"/bin/sh", "-c"}
-	}
-	c.VolumeMounts = []corev1.VolumeMount{{
-		Name:      constants.HomeVolumeName,
-		MountPath: constants.HomeUserDirectory,
-	}}
-	return nil
-}

--- a/pkg/library/home/testdata/persistent-home/skips-builtin-init-when-custom-configured.yaml
+++ b/pkg/library/home/testdata/persistent-home/skips-builtin-init-when-custom-configured.yaml
@@ -33,5 +33,21 @@ output:
               path: /home/user/
       - name: my-defined-volume
         volume: {}
+      - name: init-persistent-home
+        container:
+          image: custom-init-image
+          command:
+            - /bin/sh
+            - -c
+          volumeMounts:
+            - name: persistent-home
+              path: /home/user/
       - name: persistent-home
         volume: {}
+    commands:
+      - id: init-persistent-home
+        apply:
+          component: init-persistent-home
+    events:
+      preStart:
+        - init-persistent-home

--- a/pkg/library/home/testdata/persistent-home/skips-builtin-init-when-custom-configured.yaml
+++ b/pkg/library/home/testdata/persistent-home/skips-builtin-init-when-custom-configured.yaml
@@ -1,0 +1,37 @@
+name: "Skips built-in init container when custom init-persistent-home is configured in DWOC"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  config:
+    workspace:
+      persistUserHome:
+        enabled: true
+      initContainers:
+        - name: init-persistent-home
+          image: custom-init-image
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          volumeMounts:
+            - name: my-defined-volume
+              path: /my-defined-volume-path
+      - name: my-defined-volume
+        volume: {}
+
+output:
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          volumeMounts:
+            - name: my-defined-volume
+              path: /my-defined-volume-path
+            - name: persistent-home
+              path: /home/user/
+      - name: my-defined-volume
+        volume: {}
+      - name: persistent-home
+        volume: {}


### PR DESCRIPTION
## Summary

Adds ability to configure custom init containers via DWOC config.workspace.initContainers.

## Features
- Custom init-persistent-home override support
- Additional arbitrary init containers
- Validation for init-persistent-home command
- Backward compatible: no-op when initContainers not configured

## Testing
Unit tests added for all new functions and reconciler injection logic.