### PR TITLE
feat: validate command in init-persistent-home container (CRW-9373/CRW-9367)

### DIFF
--- a/pkg/library/home/custom_init_test.go
+++ b/pkg/library/home/custom_init_test.go
@@ -219,6 +219,65 @@ func TestCustomInitPersistentHome(t *testing.T) {
 	}
 }
 
+func TestEnsureHomeInitContainerFields(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputCommand  []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:         "NoCommand: sets default command and VolumeMounts, returns nil",
+			inputCommand: nil,
+			expectError:  false,
+		},
+		{
+			name:         "ValidCommand: exact [/bin/sh, -c] accepted, sets VolumeMounts, returns nil",
+			inputCommand: []string{"/bin/sh", "-c"},
+			expectError:  false,
+		},
+		{
+			name:          "InvalidCommand: wrong binary /usr/bin/bash returns error",
+			inputCommand:  []string{"/usr/bin/bash", "-c"},
+			expectError:   true,
+			errorContains: "command must be exactly [/bin/sh, -c]",
+		},
+		{
+			name:          "InvalidCommand: missing -c argument [/bin/sh] returns error",
+			inputCommand:  []string{"/bin/sh"},
+			expectError:   true,
+			errorContains: "command must be exactly [/bin/sh, -c]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			container := &corev1.Container{
+				Name:    "init-persistent-home",
+				Command: tt.inputCommand,
+			}
+
+			err := EnsureHomeInitContainerFields(container)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, []string{"/bin/sh", "-c"}, container.Command)
+				assert.Equal(t, []corev1.VolumeMount{
+					{
+						Name:      constants.HomeVolumeName,
+						MountPath: constants.HomeUserDirectory,
+					},
+				}, container.VolumeMounts)
+			}
+		})
+	}
+}
+
 func TestInferWorkspaceImage(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/library/home/persistentHome.go
+++ b/pkg/library/home/persistentHome.go
@@ -17,6 +17,7 @@ package home
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	devfilevalidation "github.com/devfile/api/v2/pkg/validation"
@@ -250,8 +251,12 @@ func inferInitContainer(dwTemplateSpec *v1alpha2.DevWorkspaceTemplateSpec) *v1al
 // EnsureHomeInitContainerFields ensures that an init-persistent-home container has
 // the correct Command and VolumeMounts.
 func EnsureHomeInitContainerFields(c *corev1.Container) error {
-	// Set default command only if not provided
-	if len(c.Command) == 0 {
+	// Validate or set default command
+	if len(c.Command) > 0 {
+		if !reflect.DeepEqual(c.Command, []string{"/bin/sh", "-c"}) {
+			return fmt.Errorf("command must be exactly [/bin/sh, -c]")
+		}
+	} else {
 		c.Command = []string{"/bin/sh", "-c"}
 	}
 	c.VolumeMounts = []corev1.VolumeMount{{


### PR DESCRIPTION
## Summary

This PR adds input validation to the `EnsureHomeInitContainerFields` function in the persistent home library to prevent misconfigured init containers from being silently accepted.

### What was missing

Previously, `EnsureHomeInitContainerFields` would only set a default command (`[/bin/sh, -c]`) if no command was specified on the init container. However, if a user provided a custom `command` field on the `init-persistent-home` container via `DevWorkspace.spec.template.components[].container`, it would be accepted without validation. This allowed arbitrary or invalid commands to be set on the container, potentially causing workspace startup failures that are difficult to diagnose.

### What was added

**Validation in `EnsureHomeInitContainerFields`** (`pkg/library/home/persistentHome.go`):
- If a command is already set on the container, it is now validated to be exactly `[/bin/sh, -c]`
- If the command does not match, an error is returned describing the constraint
- If no command is set (nil/empty), the default `[/bin/sh, -c]` is applied as before (no behavior change)

**New unit tests** (`pkg/library/home/custom_init_test.go`):
- `TestEnsureHomeInitContainerFields` with 4 test cases:
  - No command: sets default and volume mounts (happy path)
  - Valid command `[/bin/sh, -c]`: accepted without error
  - Invalid command `[/usr/bin/bash, -c]`: returns error with descriptive message
  - Incomplete command `[/bin/sh]` (missing `-c` argument): returns error

### References

- CRW-9373: Validate init-persistent-home container command field
- CRW-9367: EnsureHomeInitContainerFields should reject unknown commands

## Test plan

- [x] `go vet ./...` passes with no errors
- [x] `go build ./...` passes with no errors
- [x] All non-cluster unit tests pass including new `TestEnsureHomeInitContainerFields` tests
- [x] Valid command accepted without error
- [x] Invalid commands rejected with descriptive error message