### PR TITLE
feat: validate command field in custom init-persistent-home container

### DIFF
--- a/pkg/library/home/custom_init_test.go
+++ b/pkg/library/home/custom_init_test.go
@@ -346,3 +346,68 @@ func TestInferWorkspaceImage(t *testing.T) {
 		})
 	}
 }
+
+// TestEnsureHomeInitContainerFields tests the EnsureHomeInitContainerFields function.
+// Note: No YAML fixture is created in testdata/persistent-home/ for this function because
+// EnsureHomeInitContainerFields is NOT on the AddPersistentHomeVolume call path — it is called
+// later in the controller after MergeInitContainers. The YAML-driven tests in persistentHome_test.go
+// exercise NeedsPersistentHomeDirectory + AddPersistentHomeVolume and would never invoke this
+// validation logic. Creating an error-type fixture would cause TestPersistentHomeVolume to assert
+// an error from AddPersistentHomeVolume that is never returned, breaking existing tests.
+func TestEnsureHomeInitContainerFields(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputCommand  []string
+		expectErr     bool
+		errContains   string
+		expectCommand []string
+	}{
+		{
+			name:          "Empty command sets default [/bin/sh, -c], no error",
+			inputCommand:  []string{},
+			expectErr:     false,
+			expectCommand: []string{"/bin/sh", "-c"},
+		},
+		{
+			name:          "Valid command [/bin/sh, -c] explicitly provided, no change",
+			inputCommand:  []string{"/bin/sh", "-c"},
+			expectErr:     false,
+			expectCommand: []string{"/bin/sh", "-c"},
+		},
+		{
+			name:         "Invalid command [/bin/bash, -c] returns error",
+			inputCommand: []string{"/bin/bash", "-c"},
+			expectErr:    true,
+			errContains:  "Invalid init-persistent-home container: command must be exactly [/bin/sh, -c]",
+		},
+		{
+			name:         "Invalid command with single element [/bin/sh] returns error",
+			inputCommand: []string{"/bin/sh"},
+			expectErr:    true,
+			errContains:  "Invalid init-persistent-home container: command must be exactly [/bin/sh, -c]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			container := &corev1.Container{
+				Name:    constants.HomeInitComponentName,
+				Command: tt.inputCommand,
+			}
+
+			err := EnsureHomeInitContainerFields(container)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectCommand, container.Command)
+				// VolumeMounts are always set to persistent-home -> /home/user/ for non-error cases
+				assert.Len(t, container.VolumeMounts, 1)
+				assert.Equal(t, constants.HomeVolumeName, container.VolumeMounts[0].Name)
+				assert.Equal(t, constants.HomeUserDirectory, container.VolumeMounts[0].MountPath)
+			}
+		})
+	}
+}

--- a/pkg/library/home/custom_init_test.go
+++ b/pkg/library/home/custom_init_test.go
@@ -30,10 +30,9 @@ import (
 
 func TestCustomInitPersistentHome(t *testing.T) {
 	tests := []struct {
-		name                    string
-		workspace               *common.DevWorkspaceWithConfig
-		expectDefaultInitAdded  bool
-		expectCustomInitSkipped bool
+		name                   string
+		workspace              *common.DevWorkspaceWithConfig
+		expectDefaultInitAdded bool
 	}{
 		{
 			name: "Adds default init when custom init-persistent-home is provided",
@@ -215,6 +214,116 @@ func TestCustomInitPersistentHome(t *testing.T) {
 				}
 			}
 			assert.True(t, hasPersistentHomeVolume, "persistent-home volume should always be added")
+		})
+	}
+}
+
+// TestNeedsPersistentHomeDirectoryEphemeral covers the ephemeral storage branch introduced in T1.
+// When the workspace storage type is "ephemeral", NeedsPersistentHomeDirectory only returns true
+// if an init-persistent-home container is explicitly configured in the DWOC — this ensures
+// consistent behaviour between ephemeral and non-ephemeral workspaces for custom init setups.
+func TestNeedsPersistentHomeDirectoryEphemeral(t *testing.T) {
+	baseComponents := []dw.Component{
+		{
+			Name: "main",
+			ComponentUnion: dw.ComponentUnion{
+				Container: &dw.ContainerComponent{
+					Container: dw.Container{Image: "test:latest"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		workspace   *common.DevWorkspaceWithConfig
+		expectNeeds bool
+	}{
+		{
+			name: "Ephemeral workspace without custom init-persistent-home returns false",
+			workspace: &common.DevWorkspaceWithConfig{
+				DevWorkspace: &dw.DevWorkspace{
+					Spec: dw.DevWorkspaceSpec{
+						Template: dw.DevWorkspaceTemplateSpec{
+							DevWorkspaceTemplateSpecContent: dw.DevWorkspaceTemplateSpecContent{
+								Attributes: attributes.Attributes{}.
+									PutString(constants.DevWorkspaceStorageTypeAttribute, constants.EphemeralStorageClassType),
+								Components: baseComponents,
+							},
+						},
+					},
+				},
+				Config: &v1alpha1.OperatorConfiguration{
+					Workspace: &v1alpha1.WorkspaceConfig{
+						PersistUserHome: &v1alpha1.PersistentHomeConfig{
+							Enabled: ptr.To(true),
+						},
+						// No InitContainers with HomeInitComponentName
+						InitContainers: []corev1.Container{
+							{Name: "some-other-init", Image: "other:latest"},
+						},
+					},
+				},
+			},
+			expectNeeds: false,
+		},
+		{
+			name: "Ephemeral workspace with custom init-persistent-home in DWOC returns true",
+			workspace: &common.DevWorkspaceWithConfig{
+				DevWorkspace: &dw.DevWorkspace{
+					Spec: dw.DevWorkspaceSpec{
+						Template: dw.DevWorkspaceTemplateSpec{
+							DevWorkspaceTemplateSpecContent: dw.DevWorkspaceTemplateSpecContent{
+								Attributes: attributes.Attributes{}.
+									PutString(constants.DevWorkspaceStorageTypeAttribute, constants.EphemeralStorageClassType),
+								Components: baseComponents,
+							},
+						},
+					},
+				},
+				Config: &v1alpha1.OperatorConfiguration{
+					Workspace: &v1alpha1.WorkspaceConfig{
+						PersistUserHome: &v1alpha1.PersistentHomeConfig{
+							Enabled: ptr.To(true),
+						},
+						InitContainers: []corev1.Container{
+							{Name: constants.HomeInitComponentName, Image: "custom:latest"},
+						},
+					},
+				},
+			},
+			expectNeeds: true,
+		},
+		{
+			name: "Non-ephemeral workspace returns true regardless of custom init config",
+			workspace: &common.DevWorkspaceWithConfig{
+				DevWorkspace: &dw.DevWorkspace{
+					Spec: dw.DevWorkspaceSpec{
+						Template: dw.DevWorkspaceTemplateSpec{
+							DevWorkspaceTemplateSpecContent: dw.DevWorkspaceTemplateSpecContent{
+								Components: baseComponents,
+							},
+						},
+					},
+				},
+				Config: &v1alpha1.OperatorConfiguration{
+					Workspace: &v1alpha1.WorkspaceConfig{
+						PersistUserHome: &v1alpha1.PersistentHomeConfig{
+							Enabled: ptr.To(true),
+						},
+						// No custom init-persistent-home, but non-ephemeral should still need it
+					},
+				},
+			},
+			expectNeeds: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NeedsPersistentHomeDirectory(tt.workspace)
+			assert.Equal(t, tt.expectNeeds, result,
+				"NeedsPersistentHomeDirectory returned unexpected value")
 		})
 	}
 }

--- a/pkg/library/home/persistentHome.go
+++ b/pkg/library/home/persistentHome.go
@@ -253,6 +253,8 @@ func EnsureHomeInitContainerFields(c *corev1.Container) error {
 	// Set default command only if not provided
 	if len(c.Command) == 0 {
 		c.Command = []string{"/bin/sh", "-c"}
+	} else if len(c.Command) != 2 || c.Command[0] != "/bin/sh" || c.Command[1] != "-c" {
+		return fmt.Errorf("Invalid %s container: command must be exactly [/bin/sh, -c]", constants.HomeInitComponentName)
 	}
 	c.VolumeMounts = []corev1.VolumeMount{{
 		Name:      constants.HomeVolumeName,


### PR DESCRIPTION
## Summary

This PR adds validation for the `command` field in the custom `init-persistent-home` init container in `EnsureHomeInitContainerFields`.

### What the validation does

When a custom `init-persistent-home` init container is specified (via the `DWOC` operator config), the container's `Command` field is now validated. If the `command` field is set but does not match the expected `[/bin/sh, -c]`, the workspace is failed with the following error surfaced in workspace status:

```
Invalid init-persistent-home container: command must be exactly [/bin/sh, -c]
```

If the `command` field is not set (empty), a default of `[/bin/sh, -c]` is applied automatically.

This validation fixes CRW-9373 / CRW-9367 by ensuring misconfigured custom init containers produce a clear, actionable error instead of silently producing a broken workspace.

### Files changed

- `pkg/library/home/persistentHome.go` — Added command validation in `EnsureHomeInitContainerFields`
- `pkg/library/home/custom_init_test.go` — Added unit tests covering: valid command, invalid command (wrong values, wrong length), and empty command (default applied)

### How to test

Run the home package unit tests:

```bash
go test ./pkg/library/home/...
```

All tests should pass, including the new `TestEnsureHomeInitContainerFields` test cases.

## References

- CRW-9373
- CRW-9367